### PR TITLE
docs: Input Plumber Fix

### DIFF
--- a/contrib/aur/z13ctl-bin.install
+++ b/contrib/aur/z13ctl-bin.install
@@ -1,10 +1,16 @@
 post_install() {
     z13ctl setup
     systemctl --global enable z13ctl.socket z13ctl.service || true
+    echo ""
+    echo ">>> z13ctl installed. To start the daemon now (without logging out):"
+    echo ">>>   systemctl --user start z13ctl.socket"
+    echo ">>> Or log out and back in — socket activation starts automatically."
 }
 
 post_upgrade() {
-    udevadm control --reload-rules
-    udevadm trigger
-    systemctl daemon-reload || true
+    z13ctl setup
+    echo ""
+    echo ">>> z13ctl upgraded. Reload the user daemon and restart the service:"
+    echo ">>>   systemctl --user daemon-reload"
+    echo ">>>   systemctl --user restart z13ctl.service"
 }

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -180,5 +180,101 @@ ch, cancel, err := api.Subscribe([]string{"gui-toggle"})
 
 See the [API](api.md) page for details.
 
-If another tool needs exclusive access to the button device, start the daemon
-with `--no-button` to skip the button watcher entirely.
+### InputPlumber compatibility
+
+On gaming distributions such as Bazzite and ChimeraOS, [InputPlumber](https://github.com/ShadowBlip/InputPlumber)
+ships a built-in device profile for the ROG Flow Z13 (`50-rog_flow_z13.yaml`)
+that grabs `"Asus WMI hotkeys"` as a managed source device. This creates an
+exclusive evdev conflict: z13ctl cannot open the device and will log:
+
+```
+button watcher stopped; retrying err="open /dev/input/eventN: permission denied"
+```
+
+**Workaround:** Create an override config that marks `"Asus WMI hotkeys"` as
+`ignore: true`. This tells InputPlumber to leave that device unmanaged so z13ctl
+can grab it exclusively, while preserving all other InputPlumber functionality
+(controller emulation, touchpad, etc.).
+
+First, check whether the built-in config exists on your system:
+
+```sh
+cat /usr/share/inputplumber/devices/50-rog_flow_z13.yaml
+```
+
+If found, create the override directory if needed, then save the override file:
+
+```sh
+sudo mkdir -p /etc/inputplumber/devices.d
+```
+
+Create `/etc/inputplumber/devices.d/50-rog_flow_z13.yaml` with `ignore: true` added
+to the keyboard source device:
+
+```yaml
+# /etc/inputplumber/devices.d/50-rog_flow_z13.yaml
+version: 1
+kind: CompositeDevice
+name: ASUS ROG Flow Z13 (2025)
+single_source: false
+
+matches:
+  - dmi_data:
+      board_name: GZ302EA
+      sys_vendor: ASUSTeK COMPUTER INC.
+
+source_devices:
+  - group: keyboard
+    ignore: true        # allow z13ctl to grab this device exclusively
+    evdev:
+      name: Asus WMI hotkeys
+      handler: event*
+
+options:
+  auto_manage: true
+
+target_devices:
+  - xbox-elite
+  - touchpad
+  - keyboard
+
+capability_map_id: flw1
+```
+
+!!! note
+    Always place overrides under `/etc/inputplumber/devices.d/` — never edit files
+    under `/usr/share/inputplumber/devices/` directly, as those are owned by the
+    package and will be overwritten on upgrades.
+
+    If your model's `board_name` differs from `GZ302EA`, verify it with:
+    ```sh
+    cat /sys/class/dmi/id/board_name
+    ```
+
+After saving the file, restart InputPlumber:
+
+```sh
+sudo systemctl restart inputplumber.service
+```
+
+Then restore device permissions that the previous InputPlumber instance may have
+changed (InputPlumber restricts device node access while managing a device, and may
+not fully restore permissions on shutdown):
+
+```sh
+sudo z13ctl setup --perms-only
+```
+
+Then confirm z13ctl can grab the button:
+
+```sh
+journalctl --user -u z13ctl.service -f
+# Should show: watching Armoury Crate button path=/dev/input/eventN
+```
+
+Alternatively, disable the button watcher entirely and let InputPlumber handle
+the button exclusively:
+
+```sh
+z13ctl --no-button daemon
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,13 @@
 - Linux kernel with `hidraw` support (standard on all mainstream distributions)
 - 2025 ASUS ROG Flow Z13 (USB IDs `0b05:18c6` and `0b05:1a30`)
 
+!!! warning "InputPlumber conflict (Bazzite, ChimeraOS, Nobara)"
+    On gaming distributions that ship [InputPlumber](https://github.com/ShadowBlip/InputPlumber),
+    the z13ctl daemon's button watcher will fail to open the Armoury Crate button
+    device. InputPlumber ships a built-in profile for the ROG Flow Z13 that grabs
+    the device exclusively. See [InputPlumber compatibility](daemon.md#inputplumber-compatibility)
+    for the override instructions.
+
 ### Optional: ryzen_smu kernel module (for undervolting)
 
 CPU undervolting via AMD Curve Optimizer requires the `ryzen_smu` kernel
@@ -15,7 +22,7 @@ return a helpful error explaining how to install the module.
     The original `leogx9r/ryzen_smu` does not support Strix Halo (the SoC in
     the 2025 Z13). You must use the
     [amkillam/ryzen_smu](https://github.com/amkillam/ryzen_smu) fork. z13ctl
-    detects the wrong fork at startup via `SMUProbeUndervolt()` and reports
+    detects the wrong fork at startup and reports
     undervolt as unavailable.
 
 | Distribution | Package | Source |
@@ -262,6 +269,13 @@ Verify with:
 ls -la /dev/hidraw*
 groups
 ```
+
+**Daemon logs "button watcher stopped; retrying … permission denied"**
+
+Another process may be holding an exclusive grab on the Armoury Crate button
+device. On gaming distributions, [InputPlumber](https://github.com/ShadowBlip/InputPlumber)
+is a common cause. See
+[InputPlumber compatibility](daemon.md#inputplumber-compatibility) for the fix.
 
 **Daemon not starting**
 

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/spf13/cobra v1.10.2
 )
 
-require github.com/godbus/dbus/v5 v5.2.2 // indirect
+require github.com/godbus/dbus/v5 v5.2.2
 
 require (
-	github.com/dahui/z13ctl/api v1.0.0
+	github.com/dahui/z13ctl/api v1.1.3
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 )
 
-replace github.com/dahui/z13ctl/api v1.0.0 => ./api
+replace github.com/dahui/z13ctl/api v1.1.3 => ./api

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dahui/z13ctl/api v1.0.0-beta h1:GSAJfHNfOHDUi+KHYisdWZFwNTWIZ/YjWcKf2WP287s=
-github.com/dahui/z13ctl/api v1.0.0-beta/go.mod h1:WaV3cyrZkszY22RbnJh05/YXMapnP3BcyiAvtyRLnj8=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/holoplot/go-evdev v0.0.0-20250804134636-ab1d56a1fe83 h1:B+A58zGFuDrvEZpPN+yS6swJA0nzqgZvDzgl/OPyefU=
@@ -15,8 +13,6 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -96,6 +96,15 @@ func Run(ctx context.Context, watchBtn bool) error {
 		}
 	}
 
+	// Restore panel overdrive if enabled (firmware may not persist this across reboot).
+	if d.state.PanelOverdrive != 0 {
+		if poErr := cli.SetPanelOverdrive(d.state.PanelOverdrive); poErr != nil {
+			slog.Warn("failed to restore panel overdrive", "err", poErr)
+		} else {
+			slog.Info("panel overdrive restored", "value", d.state.PanelOverdrive)
+		}
+	}
+
 	// Restore fan curve + TDP if last profile was "custom".
 	if d.state.Profile == "custom" {
 		if fc := d.state.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -102,7 +102,7 @@ func (d *Daemon) dispatch(req request) response {
 	case "bootsound-get":
 		return handleBootSoundGet()
 	case "paneloverdrive":
-		return handlePanelOverdrive(req)
+		return d.handlePanelOverdrive(req)
 	case "paneloverdrive-get":
 		return handlePanelOverdriveGet()
 	case "fancurve":
@@ -452,7 +452,7 @@ func handlePanelOverdriveGet() response {
 	return response{OK: true, Value: strings.TrimSpace(string(data))}
 }
 
-func handlePanelOverdrive(req request) response {
+func (d *Daemon) handlePanelOverdrive(req request) response {
 	value, err := strconv.Atoi(req.Set)
 	if err != nil || (value != 0 && value != 1) {
 		return response{OK: false, Error: "panel overdrive must be 0 or 1"}
@@ -461,6 +461,13 @@ func handlePanelOverdrive(req request) response {
 		return response{OK: false, Error: "paneloverdrive: " + err.Error()}
 	}
 	slog.Info("paneloverdrive", "set", value)
+	d.mu.Lock()
+	d.state.PanelOverdrive = value
+	s := d.state
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
 	return response{OK: true}
 }
 


### PR DESCRIPTION
## Summary

Brief description of the changes in this pull request.

## Changes

- Add documentation on how to disable inputplumber locks on the Armoury Crate button.
- Make setup instructions more explicit in the AUR package.
- Fix for panel overdrive settings not restoring on boot.

## Testing

Describe how you tested these changes. Include relevant `make test` and
`make lint` output if applicable.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes
- [x] New behavior includes tests
- [x] Documentation updated if needed
