### PR TITLE
Fix z13ctl-perms.service failure when ryzen_smu module is not loaded

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -62,7 +62,7 @@ After=sysinit.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c 'for f in /sys/class/power_supply/BAT*/charge_control_end_threshold; do [ -e "$$f" ] && chgrp %s "$$f" && chmod g+w "$$f"; done'
-ExecStart=/bin/sh -c 'for f in /sys/kernel/ryzen_smu_drv/smu_args /sys/kernel/ryzen_smu_drv/mp1_smu_cmd /sys/kernel/ryzen_smu_drv/rsmu_cmd; do [ -e "$$f" ] && chgrp %s "$$f" && chmod g+w "$$f"; done'
+ExecStart=/bin/sh -c 'for f in /sys/kernel/ryzen_smu_drv/smu_args /sys/kernel/ryzen_smu_drv/mp1_smu_cmd /sys/kernel/ryzen_smu_drv/rsmu_cmd; do [ -e "$$f" ] && chgrp %s "$$f" && chmod g+w "$$f" || true; done'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The ryzen_smu ExecStart loop exits with code 1 when none of the sysfs files exist, because `[ -e "$f" ]` returns 1 and that becomes the loop's exit status. Append `|| true` so the service succeeds regardless of whether the module is loaded.