### PR TITLE
fix: custom fan curves survive power profile changes; lower the high-TDP fan floor to 50%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ internal/
                              eventDevice seam — no Grab method, see issue #10
     button_test.go           device discovery + read-loop filtering (fake evdev device)
     hotplug.go               detachable-keyboard reattach watcher (polls sysfs, reopens HID + restores lighting)
+    reconcile.go             custom fan curve / high-TDP floor watcher; pure reconcileTick seam + reconcileOnce
+    reconcile_test.go        reconcileTick decision table (no hardware) + reconcileOnce race guard
     server.go                JSON request handler; handleConn(), dispatch(), command handlers, restoreStockPPT(), effectiveProfile()
     server_test.go           request validation + dispatch routing (no hardware access)
     state_test.go            state persistence: round-trip, corrupt-file preservation, temp cleanup
@@ -223,24 +225,58 @@ contrib/
 - **Fan curves**: Two hwmon devices under asus-nb-wmi: `asus` (RPM readings +
   `pwm_enable`) and `asus_custom_fan_curve` (8-point curves + `pwm_enable`).
   hwmon numbers are unstable across reboots — discovery by `name` sysfs attribute
-  via `FindFanHwmonPath()`. Both hwmon devices expose `pwm_enable` and both must
-  be written for the kernel to honor the mode change. `pwm_enable` values:
-  0=full-speed, 1=custom, 2=auto/firmware. Both fans cool the same APU (no
-  discrete GPU), so the same curve is always applied to both fans simultaneously.
+  via `FindFanHwmonPath()`. `pwm_enable` values: 0=full-speed, 1=custom,
+  2=auto/firmware. Modes 1 and 2 go to the **curve device only**: the base `asus`
+  device is `fan_type` SPEC83 on the Z13, whose `pwm1_enable_store` accepts just 0
+  and 2 (mode 1 is `-EINVAL`) and clears `custom_fan_curves[*].enabled` for every
+  fan before returning — so syncing the mode there, which z13ctl did through
+  v1.2.1, would disable the curve it had just enabled on any kernel or SKU that
+  accepts the write. Only `SetAllFansFullSpeed` (mode 0) and the RPM reads use the
+  base device. Both fans cool the same APU (no discrete GPU), so the same curve is
+  always applied to both fans simultaneously.
+- **A custom fan curve is dropped by any `platform_profile` write** (issue #15).
+  `throttle_thermal_policy_write()` — which every profile write goes through —
+  ends by clearing `custom_fan_curves[*].enabled`, and `fan_curve_write()` then
+  returns early on `!enabled`. Nothing is reported to the process that set the
+  curve. On a GNOME desktop, power-profiles-daemon writes `platform_profile` on
+  every AC/battery transition and on any PPD hold, so a curve set by z13ctl stops
+  working minutes later for no visible reason; Fn+F5, asusctl and tuned do the
+  same. Two halves fix it: `SetBothFanCurves` reads `pwm_enable` back
+  (`VerifyFanCurveActive`) so a dropped curve is an error rather than a false
+  success — which is also what makes `ApplyTDPSafely` genuinely fail closed — and
+  `internal/daemon/reconcile.go` polls the curve device's `pwm_enable` every 2s
+  and re-applies. It polls the enable flag rather than `platform_profile` because
+  `fan_curve_enable_show()` returns the driver's cached `enabled`, making it
+  ground truth and catching every cause rather than the one we predicted. It
+  never writes `platform_profile` (that would be a write-fight with PPD over
+  every AC transition) and acts only while `state.Profile == "custom"`, so a
+  deliberate stock-profile switch is left alone by construction.
+- **`hwMu` guards hardware mutation sequences; lock order is `hwMu` then `d.mu`.**
+  `d.mu` guards state, and every mutating handler does its hardware I/O outside
+  it, so nothing otherwise stops the reconcile watcher interleaving its
+  `SetBothFanCurves` with `handleProfile`'s `ResetAllFanCurves` — the fans would
+  keep whichever mode landed last. `handleProfile`'s "custom" branch used to hold
+  `d.mu` across the `cli.*` calls and now snapshots first, so the order holds
+  everywhere. `*-get` handlers deliberately do not take `hwMu`: blocking a GUI
+  read behind a fan write sequence would be a regression.
 - **TDP (PPT power limits)**: Direct platform device attributes at
   `/sys/devices/platform/asus-nb-wmi/ppt_*` (NOT the firmware-attributes interface,
   which has empty calibration data). Five attributes: `ppt_pl1_spl` (Sustained),
   `ppt_pl2_sppt` (Short Boost), `ppt_fppt` (Fast Boost), `ppt_apu_sppt`,
   `ppt_platform_sppt`. Safety limits: 5–75W (safe), up to 93W with `--force`
   (G-Helper absolute max for 2025 Z13 GZ302E). When the **sustained** limit
-  (PL1) exceeds 75W, both fans are written `HighTDPFanCurve` — an 80% PWM floor
-  with `pwm_enable=1` — before the PPT writes, and the TDP is not applied at all
-  if that fails (see `ApplyTDPSafely`). Burst limits alone do not trigger it.
+  (PL1) exceeds 75W, both fans are written `HighTDPFanCurve` — a 50% PWM floor
+  with `pwm_enable=1`, ramping to 100% at 80°C — before the PPT writes, and the
+  TDP is not applied at all if that fails (see `ApplyTDPSafely`). The floor was
+  80% (204) through v1.2.1 and users reported it as loud enough that they simply
+  stopped using high TDP, so it is now 127; the *ramp* is what protects the APU,
+  since a machine actually sustaining >75W is well past 60°C where the curve is
+  far above the floor anyway. Burst limits alone do not trigger it.
   `SetAllFansFullSpeed` (`pwm_enable=0`) is an earlier strategy that nothing
   calls any more; the docs, the dry-run output, and this file all described it
   for far longer than the code did. APU sPPT and Platform sPPT always follow PL2.
 - **`cli.ApplyTDPSafely` is the only way to apply a custom TDP.** Above
-  `TDPMaxSafe` (75W) the fans must be held to an 80% PWM floor
+  `TDPMaxSafe` (75W) the fans must be held to a 50% PWM floor
   (`HighTDPFanCurve`). Five paths apply a TDP — `handleTDP`, the `handleProfile`
   "custom" branch, daemon startup, resume, and `cmd/tdp.go`'s no-daemon path —
   and they previously enforced this four different ways: two warned and applied

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ z13ctl profile --set balanced
 z13ctl batterylimit --set 80
 
 # Custom fan curve (8-point, temp:pwm pairs — both fans)
+# The kernel drops custom curves on every power profile change; run the daemon
+# and it re-applies yours automatically.
 z13ctl fancurve --set "48:2,53:22,57:30,60:43,63:56,65:68,70:89,76:102"
 
 # Set TDP to 50W

--- a/cmd/fancurve.go
+++ b/cmd/fancurve.go
@@ -39,8 +39,15 @@ must be non-decreasing.
 
 With --reset, restores firmware auto mode (pwm_enable=2) for both fans.
 
+The mode shown by --get is the truth: "custom" means the kernel is honouring
+your curve, "auto" means it is not, whatever points are listed. The kernel
+driver discards custom fan curves on every system power profile change — GNOME
+power modes, power-profiles-daemon (including its automatic AC/battery
+switching), Fn+F5, asusctl. Run the daemon and it re-applies your curve within
+a couple of seconds; without it, re-run --set after any profile change.
+
 Safety: while sustained TDP (PL1) is above 75W, every curve point must be at
-least 204 PWM (80%) and --reset is refused, since firmware auto mode has no
+least 127 PWM (50%) and --reset is refused, since firmware auto mode has no
 minimum. Lower the limit first with 'z13ctl tdp --reset'.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -111,6 +118,9 @@ func runFanCurveSet() error {
 			return err
 		}
 		fmt.Println("Fan curves set for both fans (custom mode enabled)")
+		fmt.Println("  Note: the kernel driver drops custom fan curves whenever the system power")
+		fmt.Println("  profile changes (GNOME power modes, power-profiles-daemon, Fn+F5). The z13ctl")
+		fmt.Println("  daemon watches for that and re-applies this curve within a couple of seconds.")
 		return nil
 	}
 
@@ -118,6 +128,10 @@ func runFanCurveSet() error {
 		return fmt.Errorf("setting fan curves: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
 	}
 	fmt.Println("Fan curves set for both fans (custom mode enabled)")
+	fmt.Println("  Warning: the kernel driver drops custom fan curves whenever the system power")
+	fmt.Println("  profile changes (GNOME power modes, power-profiles-daemon, Fn+F5), and the")
+	fmt.Println("  z13ctl daemon is not running to restore it. Re-run this command after any")
+	fmt.Println("  profile change, or start the daemon (see 'z13ctl daemon').")
 	return nil
 }
 

--- a/cmd/tdp.go
+++ b/cmd/tdp.go
@@ -37,9 +37,16 @@ the same value. Use --pl1, --pl2, --pl3 to override individual limits.
 
 Safety: The sustained power limit (PL1) is capped at 75W by default. Use --force
 to allow PL1 up to 93W (the absolute hardware maximum for the ROG Flow Z13
-GZ302E). When PL1 exceeds 75W, fans are automatically set to full speed for
-thermal safety. Burst limits (PL2/PL3) are allowed up to 93W without --force
-since short bursts are thermally safe.
+GZ302E). When PL1 exceeds 75W, both fans are held to a curve with a 50% PWM
+floor that reaches 100% at 80°C, written before the power limit; if that write
+fails, or the kernel does not honour it, the TDP is not applied at all. Burst
+limits (PL2/PL3) are allowed up to 93W without --force since short bursts are
+thermally safe.
+
+Run the daemon when sustaining above 75W. The kernel releases custom fan curves
+on every system power profile change while the power limit survives it, so
+without the daemon to restore the floor the machine can end up at high power on
+the firmware's ordinary fan curve.
 
 With --reset, switches to the balanced profile, resets fan curves to auto mode,
 and writes balanced's stock PPT values back to hardware. The firmware manages
@@ -160,17 +167,25 @@ func runTdpSet() error {
 		if err != nil {
 			return err
 		}
+		if pl1 > cli.TDPMaxSafe {
+			fmt.Println("Fans set to 50%+ curve for thermal safety (the daemon keeps that floor in")
+			fmt.Println("  force if a power profile change releases it)")
+		}
 		fmt.Printf("TDP set to %dW\n", watts)
 		return nil
 	}
 
-	// Direct path: same helper, so the no-daemon path enforces the 80% fan floor
+	// Direct path: same helper, so the no-daemon path enforces the 50% fan floor
 	// on the same terms — fans first, and no TDP at all if that write fails.
 	if err := cli.ApplyTDPSafely(cli.TDPStateFor(watts, pl1, pl2, pl3)); err != nil {
 		return fmt.Errorf("setting TDP: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
 	}
 	if pl1 > cli.TDPMaxSafe {
-		fmt.Println("Fans set to 80%+ curve for thermal safety")
+		fmt.Println("Fans set to 50%+ curve for thermal safety")
+		fmt.Println("  Warning: a system power profile change (GNOME power modes,")
+		fmt.Println("  power-profiles-daemon, Fn+F5) releases that floor in the kernel driver while")
+		fmt.Println("  this power limit stays in force, and the z13ctl daemon is not running to")
+		fmt.Println("  restore it. Start the daemon (see 'z13ctl daemon') before sustaining >75W.")
 	}
 	fmt.Printf("TDP set to %dW\n", watts)
 	return nil

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -220,6 +220,17 @@ z13ctl fancurve [flags]
 | `--set <curve>` | Set a custom 8-point fan curve (applied to both fans) |
 | `--reset` | Reset both fans to firmware auto mode |
 
+The **mode** in `--get` output is the one to read. `custom` means the kernel is
+honouring your curve; `auto` means it is not, regardless of which points are
+listed underneath — the driver keeps the curve data after disabling it.
+
+```
+$ z13ctl fancurve --get
+Fans: 4400 RPM, mode: custom, APU: 43°C   # <- your curve is live
+$ z13ctl fancurve --get
+Fans: 1200 RPM, mode: auto, APU: 48°C     # <- it is not; see the warning below
+```
+
 **Curve format:** 8 comma-separated `temp:speed` pairs. Speed can be a PWM
 value (0–255) or a percentage with a `%` suffix (0–100%). Both formats can be
 mixed in the same curve.
@@ -235,9 +246,26 @@ mixed in the same curve.
 - Temperatures must be monotonically increasing (0–120 &deg;C)
 - Speed values must be non-decreasing (0–255 PWM or 0–100%)
 
+!!! warning "A power profile change wipes your custom curve"
+    The kernel's `asus-wmi` driver disables custom fan curves on every
+    `platform_profile` write, silently. GNOME power modes and
+    `power-profiles-daemon` do that on each AC/battery transition, so does Fn+F5,
+    and so does `asusctl`. Run the [daemon](daemon.md) and it puts your curve back
+    within a couple of seconds; without it, re-run `--set` after any profile
+    change. Since 1.2.2 the command errors out instead of reporting success when
+    the kernel refuses the curve.
+
+    To confirm it for yourself, read the driver's own flag — `1` is custom,
+    `2` is firmware auto:
+
+    ```sh
+    curve=$(grep -l asus_custom_fan_curve /sys/class/hwmon/hwmon*/name | xargs dirname)
+    cat $curve/pwm1_enable
+    ```
+
 !!! warning "Fan control is restricted above 75 W sustained TDP"
     While sustained TDP (PL1) is above 75 W, every curve point must be at least
-    204 PWM (80%), and `--reset` is refused — firmware auto mode has no floor,
+    127 PWM (50%), and `--reset` is refused — firmware auto mode has no floor,
     and dropping to it would remove the cooling the power limit depends on.
     Lower the limit first with [`z13ctl tdp --reset`](#tdp), which restores the
     balanced profile before releasing the fans.
@@ -276,7 +304,7 @@ z13ctl tdp [flags]
 | `--pl1 <watts>` | Override PL1/SPL independently |
 | `--pl2 <watts>` | Override PL2/sPPT independently |
 | `--pl3 <watts>` | Override PL3/fPPT independently |
-| `--force` | Allow sustained TDP (PL1) above 75W (up to 93W). Burst limits (PL2/PL3) are allowed up to 93W without `--force`. When PL1 exceeds 75W, fans are set to an 80% minimum curve; custom curves must keep all PWM values at or above 204 (80%). |
+| `--force` | Allow sustained TDP (PL1) above 75W (up to 93W). Burst limits (PL2/PL3) are allowed up to 93W without `--force`. When PL1 exceeds 75W, fans are set to a 50% minimum curve; custom curves must keep all PWM values at or above 127 (50%). |
 
 **PPT attributes:**
 
@@ -311,9 +339,28 @@ re-selectable.
   5–93W. Burst limits (PL2/PL3) may go to 93W without `--force`, since short
   bursts are thermally safe.
 - When the **sustained** limit exceeds 75W, both fans are held to a minimum of
-  204 PWM (80%) before the TDP values are written. If that fan write fails, the
-  TDP is not applied at all. Burst limits above 75W do not trigger this on their
-  own.
+  127 PWM (50%) before the TDP values are written. If that fan write fails — or
+  the kernel accepts it and then drops the curve — the TDP is not applied at all.
+  Burst limits above 75W do not trigger this on their own.
+- The floor is only the bottom of the curve. Above 50 °C it climbs steadily and
+  reaches 100% at 80 °C, which is the range a machine actually sustaining more
+  than 75 W spends its time in:
+
+    | Temp | 30 °C | 40 °C | 50 °C | 60 °C | 65 °C | 70 °C | 75 °C | 80 °C |
+    |------|-------|-------|-------|-------|-------|-------|-------|-------|
+    | PWM  | 127   | 127   | 140   | 165   | 190   | 215   | 235   | 255   |
+
+    A custom curve may replace it as long as every point stays at or above 127.
+    The floor was 204 (80%) through v1.2.1 — loud enough that users were turning
+    the feature off rather than living with it, which protects nobody.
+
+!!! danger "Run the daemon when sustaining above 75 W"
+    The kernel releases custom fan curves on every `platform_profile` write, and
+    the power limit survives it — so a GNOME power mode change or an AC/battery
+    transition can leave the machine drawing >75 W sustained with the fans back on
+    the firmware's ordinary curve. The [daemon](daemon.md) watches for that and
+    restores the floor within a couple of seconds. Without it, that state persists
+    until you re-apply the curve yourself.
 
 ```sh
 # Read current TDP values
@@ -325,7 +372,7 @@ z13ctl tdp --set 50
 # Set with individual PL overrides
 z13ctl tdp --set 45 --pl2 55 --pl3 60
 
-# Force high sustained TDP (fans are held to an 80% floor first)
+# Force high sustained TDP (fans are held to a 50% floor first)
 z13ctl tdp --set 85 --force
 
 # Reset to balanced profile (restores balanced's stock PPT and clears the undervolt)

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -12,6 +12,9 @@ ordinary one-shot CLI invocations cannot:
 - **Keyboard reattach recovery** — detects the detachable keyboard being removed
   and reattached, reopens the HID device, and re-applies the saved keyboard
   lighting (the firmware does not restore it on its own).
+- **Custom fan curve reconciliation** — re-applies your custom fan curve (and the
+  high-TDP fan floor) after the kernel driver drops it, which it does on every
+  system power profile change.
 - **HID device ownership** — holds the hidraw devices open continuously so that
   commands arrive instantly rather than waiting to reopen the device each time.
 - **Armoury Crate button events** — captures `KEY_PROG3` (the dedicated Armoury
@@ -162,7 +165,7 @@ The `pl1`/`pl2`/`pl3` fields are optional overrides; `set` alone applies one
 value to all three. `force` is required for a sustained limit (PL1) above 75 W.
 
 !!! warning "Fan commands are restricted above 75 W sustained TDP"
-    While PL1 is above 75 W, both fans are held to a minimum of 204 PWM (80%).
+    While PL1 is above 75 W, both fans are held to a minimum of 127 PWM (50%).
     `fancurve` is rejected if any point falls below that floor, and
     `fancurve-reset` is rejected outright — firmware auto mode has no minimum.
     `tdp-reset` is the way out: it lowers the limit before releasing the fans.
@@ -274,7 +277,8 @@ Several hardware settings are volatile — they are lost when the system enters
 sleep (suspend/hibernate) and must be reapplied on resume:
 
 - **Lighting** — RGB lighting is turned off by the hardware on sleep
-- **Fan curves** — custom PWM curves reset to firmware defaults on sleep
+- **Fan curves** — custom PWM curves reset to firmware defaults on sleep (and on
+  every power profile change — see [reconciliation](#custom-fan-curve-reconciliation))
 - **TDP (PPT)** — power limits are lost and must be rewritten
 - **Undervolt (Curve Optimizer)** — CO offsets reset to stock on every sleep cycle
 
@@ -323,6 +327,48 @@ journalctl --user -u z13ctl -f
     This recovery only happens while the daemon is running. Without it, re-run
     your `apply` command (or press the Armoury Crate button in z13gui) after
     reattaching the keyboard.
+
+---
+
+## Custom fan curve reconciliation
+
+The kernel's `asus-wmi` driver **disables custom fan curves on every
+`platform_profile` write**. The write handler ends by clearing the driver's
+internal "custom curve enabled" flag for each fan, and the curve is then never
+pushed to the EC again until something re-enables it. Nothing is reported to the
+process that set the curve — your fans simply return to the firmware's own curve.
+
+This is easy to trigger without meaning to:
+
+- GNOME power modes and `power-profiles-daemon` write `platform_profile` on every
+  AC/battery transition and whenever an application requests a profile hold
+- Fn+F5 (the ASUS fan-mode hotkey)
+- `asusctl`, `tuned`, or any other tool that manages the platform profile
+
+The daemon polls the fan curve device's `pwm_enable` — the driver's own
+"is the custom curve live" flag, so it catches every cause — every two seconds.
+When the curve has been dropped while your saved settings say it should still be
+in force, it writes the curve back. The same applies to the 50% PWM floor that a
+sustained TDP above 75 W requires: without this, a power profile change would
+release the fans while the power limit stayed in place.
+
+```sh
+journalctl --user -u z13ctl -f
+# After a profile change: reconciling custom thermal settings
+#   reason="saved custom fan curve was disabled" platform_profile=balanced pwm_enable=2
+```
+
+The daemon never writes `platform_profile` itself — your desktop stays in charge
+of the power profile. Reconciliation only runs while the `custom` profile is
+active, so selecting `quiet`, `balanced`, or `performance` with
+`z13ctl profile --set` releases the fans to firmware control and keeps them there.
+
+!!! note "Daemon required"
+    Without the daemon, a custom fan curve set with `z13ctl fancurve --set` lasts
+    only until the next power profile change. The CLI warns about this when it
+    applies a curve directly. Since z13ctl 1.2.2 the command also fails with an
+    error, rather than reporting success, if the kernel refuses to honour the
+    curve it just wrote.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,11 @@ z13ctl batterylimit --set 100
 Both physical fans cool the same APU, so the same curve is always applied to
 both fans simultaneously.
 
+The kernel discards custom fan curves whenever the system power profile changes —
+which GNOME power modes and `power-profiles-daemon` do on every AC/battery
+transition. Run the [daemon](daemon.md) and it re-applies your curve automatically;
+otherwise re-run `--set` after any profile change.
+
 ```sh
 # Check current fan curves
 z13ctl fancurve --get
@@ -117,6 +122,11 @@ Setting a custom TDP switches to the `custom` profile. Switching back to a stock
 profile restores that profile's stock PPT values to hardware, while keeping the
 custom values saved so `custom` stays re-selectable.
 
+Sustaining more than 75 W holds both fans to a 50% PWM floor that rises to 100%
+at 80 °C. Run the [daemon](daemon.md) if you use that: a system power profile
+change releases the floor in the kernel while the power limit stays in force,
+and the daemon is what puts it back.
+
 ```sh
 # Check current TDP/PPT values
 z13ctl tdp --get
@@ -127,7 +137,7 @@ z13ctl tdp --set 50
 # Set with individual PL overrides
 z13ctl tdp --set 45 --pl2 55 --pl3 60
 
-# Force high TDP (above 75W, fans set to 80% minimum)
+# Force high TDP (above 75W, fans set to 50% minimum)
 z13ctl tdp --set 85 --force
 
 # Reset to balanced profile (restores balanced's stock PPT)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ on Linux.
 - **Fan curves** — set custom 8-point fan curves via the asus-wmi hwmon interface
   (both fans cool the same APU and share one curve)
 - **TDP control** — set CPU/GPU power limits (5–93W) via asus-nb-wmi PPT attributes,
-  with automatic fan safety above 75W
+  with an automatic fan floor (50% PWM, rising to 100% at 80 °C) above 75W sustained
 - **CPU undervolting** — reduce voltage via AMD Curve Optimizer for lower
   temperatures and power draw without reducing performance (requires `ryzen_smu`
   kernel module)
@@ -29,7 +29,9 @@ on Linux.
 
 All features work without root after a one-time `setup` step, and all persist across
 reboots when the daemon is running. The daemon also re-applies keyboard lighting
-automatically when the detachable keyboard is removed and reattached.
+automatically when the detachable keyboard is removed and reattached, and puts your
+fan curve back when the kernel discards it — which it does on every system power
+profile change (see [Daemon](daemon.md#custom-fan-curve-reconciliation)).
 
 !!! tip "New to Linux? Use the GUI"
     Most users — especially those newer to Linux — should install

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -147,6 +147,7 @@ func DryRunFanCurve(points []api.FanCurvePoint) {
 		}
 		fmt.Printf("Would write 1 (custom) to %s/pwm%d_enable\n", curveDir, f.index)
 	}
+	fmt.Printf("Would read %s/pwm*_enable back to confirm the kernel kept the curve\n", curveDir)
 }
 
 // DryRunFanCurveReset prints the sysfs writes for a fan curve reset (both fans).
@@ -181,7 +182,7 @@ func DryRunTdp(watts, pl1, pl2, pl3 int, force bool) {
 		if curveDir == "" {
 			curveDir = "<hwmon not found>"
 		}
-		fmt.Printf("Would write the high-TDP fan curve (minimum %d PWM / 80%%) to both fans in %s\n",
+		fmt.Printf("Would write the high-TDP fan curve (minimum %d PWM / 50%%) to both fans in %s\n",
 			HighTDPMinPWM, curveDir)
 		fmt.Printf("Would write 1 (custom) to %s/pwm{1,2}_enable\n", curveDir)
 		fmt.Printf("  (sustained %dW is above the %dW safe max; if the fan write fails the TDP is not applied at all)\n",

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -213,18 +214,21 @@ func TestDryRunTdp(t *testing.T) {
 
 // TestDryRunTdp_HighSustained pins the dry run against what ApplyTDPSafely
 // actually does. The old expectation here was "full speed", which the real path
-// has never done — it writes the 80% floor curve with pwm_enable=1. A dry run
+// has never done — it writes the 50% floor curve with pwm_enable=1. A dry run
 // that describes an operation the tool does not perform is worse than none.
 func TestDryRunTdp_HighSustained(t *testing.T) {
 	out := captureStdout(t, func() { cli.DryRunTdp(80, 0, 0, 0, true) })
 
-	for _, want := range []string{"204", "80%", "pwm", "not applied at all"} {
+	// Reference the constant rather than the number: the floor has moved once
+	// already (80% -> 50%) and these assertions should not need revisiting.
+	floor := strconv.Itoa(cli.HighTDPMinPWM)
+	for _, want := range []string{floor, "pwm", "not applied at all"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("DryRunTdp(80W) output missing %q; got:\n%s", want, out)
 		}
 	}
 	if strings.Contains(out, "full speed") {
-		t.Error("DryRunTdp must not claim full speed — the real path writes the 80% floor curve")
+		t.Error("DryRunTdp must not claim full speed — the real path writes the 50% floor curve")
 	}
 }
 
@@ -234,10 +238,11 @@ func TestDryRunTdp_FanFloorIgnoresForce(t *testing.T) {
 	forced := captureStdout(t, func() { cli.DryRunTdp(80, 0, 0, 0, true) })
 	unforced := captureStdout(t, func() { cli.DryRunTdp(80, 0, 0, 0, false) })
 
-	if !strings.Contains(unforced, "204") {
+	floor := strconv.Itoa(cli.HighTDPMinPWM)
+	if !strings.Contains(unforced, floor) {
 		t.Errorf("DryRunTdp(80W, no force) omitted the fan floor; got:\n%s", unforced)
 	}
-	if strings.Contains(forced, "204") != strings.Contains(unforced, "204") {
+	if strings.Contains(forced, floor) != strings.Contains(unforced, floor) {
 		t.Error("the fan floor must not depend on --force")
 	}
 }
@@ -248,7 +253,7 @@ func TestDryRunTdp_FanFloorIgnoresForce(t *testing.T) {
 func TestDryRunTdp_BurstAboveSafeMaxKeepsFansAlone(t *testing.T) {
 	out := captureStdout(t, func() { cli.DryRunTdp(50, 50, 90, 90, true) })
 
-	if strings.Contains(out, "204") || strings.Contains(out, "fan") {
+	if strings.Contains(out, strconv.Itoa(cli.HighTDPMinPWM)) || strings.Contains(out, "fan") {
 		t.Errorf("burst limits above the safe max must not imply a fan change; got:\n%s", out)
 	}
 }

--- a/internal/cli/fan.go
+++ b/internal/cli/fan.go
@@ -23,10 +23,23 @@ const (
 	fanCurvePoints = 8
 	fanCount       = 2 // fan 1 (pwm1) and fan 2 (pwm2)
 
-	// HighTDPMinPWM is the minimum PWM value (80% of 255) enforced when
+	// HighTDPMinPWM is the minimum PWM value (50% of 255) enforced when
 	// sustained TDP exceeds TDPMaxSafe. Users can set fans higher but not lower.
-	HighTDPMinPWM = 204
+	//
+	// This was 204 (80%) up to v1.2.1, which users found unreasonably loud to
+	// live with — loud enough that the realistic alternative was not running the
+	// high TDP at all. The protection that matters is the *ramp*, not the floor:
+	// a machine sustaining more than TDPMaxSafe watts sits well above 60°C, where
+	// HighTDPFanCurve is far above this minimum anyway. The floor only sets how
+	// the fans behave while the APU is still cool.
+	HighTDPMinPWM = 127
 )
+
+// fanWriteInt is the pwm_enable write used by setFanMode. It is a var purely so
+// tests can simulate the kernel's real failure mode here: accepting the write
+// and then leaving the mode unchanged, which is what a concurrent
+// platform_profile write produces. Plain files cannot reproduce that.
+var fanWriteInt = writeIntFile
 
 // fanNames maps internal fan names to their hwmon index (1 or 2).
 var fanNames = [fanCount]struct {
@@ -86,6 +99,60 @@ func ReadBothFanRPM() ([fanCount]int, error) {
 	return rpms, nil
 }
 
+// ReadFanCurveModes returns the pwm_enable value for each fan on the curve
+// hwmon device, using -1 for a channel that cannot be read. Unlike
+// ReadBothFanModes it does not fail the whole read because one channel is
+// missing: a SKU that exposes only the CPU curve is a supported configuration,
+// and the reconcile watcher must still be able to act on the channel it has.
+// An error is returned only when the hwmon device itself is absent.
+func ReadFanCurveModes() ([fanCount]int, error) {
+	dir := FindFanCurveHwmonPath()
+	if dir == "" {
+		return [fanCount]int{}, fmt.Errorf("hwmon device %q not found", hwmonNameCurves)
+	}
+	var modes [fanCount]int
+	for i, f := range fanNames {
+		v, err := readIntFile(dir + "/" + fmt.Sprintf("pwm%d_enable", f.index))
+		if err != nil {
+			modes[i] = -1
+			continue
+		}
+		modes[i] = v
+	}
+	return modes, nil
+}
+
+// VerifyFanCurveActive reports whether the kernel is actually honouring the
+// custom curve on every readable fan channel.
+//
+// fan_curve_enable_show() returns the driver's cached data->enabled flag, so
+// this file is ground truth: anything other than 1 means the curve was dropped.
+// The usual cause is a platform_profile write — throttle_thermal_policy_write()
+// ends by clearing custom_fan_curves[*].enabled for every fan, and
+// fan_curve_write() then returns early on !enabled — which is what made a
+// curve set by z13ctl silently stop working minutes later (issue #15).
+//
+// A channel that cannot be read is deliberately not a failure: unverifiable is
+// not the same as failed, and hard-failing there would make fan control (and
+// with it the high-TDP floor) unavailable on any SKU that does not expose
+// pwm2_enable on the curve device.
+func VerifyFanCurveActive() error {
+	modes, err := ReadFanCurveModes()
+	if err != nil {
+		return err
+	}
+	for i, m := range modes {
+		if m == -1 || m == 1 {
+			continue
+		}
+		return fmt.Errorf(
+			"custom fan curve was written but the kernel is not honouring it (pwm%d_enable = %d, %s): "+
+				"a platform_profile change disables custom fan curves in the kernel driver; re-apply the curve",
+			fanNames[i].index, m, FanModeName(m))
+	}
+	return nil
+}
+
 // ReadBothFanModes reads the pwm_enable value for both fans from the curve
 // hwmon device. Returns 0 (full-speed), 1 (custom), or 2 (auto/firmware).
 func ReadBothFanModes() ([fanCount]int, error) {
@@ -129,8 +196,14 @@ func ReadBothFanCurves() ([fanCount][]api.FanCurvePoint, error) {
 	return curves, nil
 }
 
-// SetBothFanCurves writes the same 8-point fan curve to both fans and enables
-// custom mode (pwm_enable=1) on both.
+// SetBothFanCurves writes the same 8-point fan curve to both fans, enables
+// custom mode (pwm_enable=1) on both, and verifies that the kernel kept it.
+//
+// The readback is not paranoia: the driver drops custom curves on any
+// platform_profile write without reporting anything to the process that set
+// them, so without it every caller reports success for a curve that is no
+// longer in effect — including ApplyTDPSafely, whose thermal floor depends on
+// this write having stuck.
 func SetBothFanCurves(points []api.FanCurvePoint) error {
 	if len(points) != fanCurvePoints {
 		return fmt.Errorf("fan curve must have exactly %d points, got %d", fanCurvePoints, len(points))
@@ -149,14 +222,25 @@ func SetBothFanCurves(points []api.FanCurvePoint) error {
 			}
 		}
 	}
-	return setAllFanModes(1) // enable custom mode on both
+	if err := setAllFanModes(1); err != nil { // enable custom mode on both
+		return err
+	}
+	return VerifyFanCurveActive()
 }
 
 // setFanMode writes pwm_enable for a single fan (by index).
-// Mode 0 (full-speed) is only supported by the base "asus" hwmon device;
-// the "asus_custom_fan_curve" device rejects it with EINVAL.
-// Modes 1 (custom) and 2 (auto) are written to the curve device first,
-// then synced to the readings device.
+//
+// Mode 0 (full-speed) is only supported by the base "asus" hwmon device; the
+// "asus_custom_fan_curve" device rejects it with EINVAL.
+//
+// Modes 1 (custom) and 2 (auto) go to the curve device *only*. The base device
+// must not be written for them: on the Z13 its fan_type is SPEC83, whose
+// pwm1_enable_store accepts just 0 (full-speed) and 2 (auto) and answers mode 1
+// with EINVAL — and, worse, it clears custom_fan_curves[*].enabled for every fan
+// before returning. On any kernel or SKU that accepts the write, syncing the
+// mode there would disable the very curve this function has just enabled.
+// z13ctl did exactly that through v1.2.1; it was inert only because the Z13
+// rejects it (issue #15).
 func setFanMode(idx, mode int) error {
 	file := fmt.Sprintf("pwm%d_enable", idx)
 
@@ -166,20 +250,15 @@ func setFanMode(idx, mode int) error {
 		if readDir == "" {
 			return fmt.Errorf("hwmon device %q not found", hwmonNameReadings)
 		}
-		return writeIntFile(readDir+"/"+file, mode)
+		return fanWriteInt(readDir+"/"+file, mode)
 	}
 
-	// Custom (1) or auto (2): write to curve device first, then sync readings.
 	curveDir := FindFanCurveHwmonPath()
 	if curveDir == "" {
 		return fmt.Errorf("hwmon device %q not found", hwmonNameCurves)
 	}
-	if err := writeIntFile(curveDir+"/"+file, mode); err != nil {
+	if err := fanWriteInt(curveDir+"/"+file, mode); err != nil {
 		return fmt.Errorf("setting fan mode on %s: %w", hwmonNameCurves, err)
-	}
-	readDir := FindFanReadingsHwmonPath()
-	if readDir != "" {
-		_ = writeIntFile(readDir+"/"+file, mode)
 	}
 	return nil
 }
@@ -204,7 +283,7 @@ func ResetAllFanCurves() error {
 // is functional — pwm2_enable returns EIO on writes. Writing pwm1_enable=0
 // is sufficient to force both physical fans to full speed.
 //
-// Nothing calls this. High-TDP cooling uses HighTDPFanCurve (an 80% PWM floor
+// Nothing calls this. High-TDP cooling uses HighTDPFanCurve (a 50% PWM floor
 // with pwm_enable=1) via ApplyTDPSafely; full speed was an earlier approach that
 // the docs, the --dry-run output, and CLAUDE.md all went on describing long
 // after the code stopped doing it. Kept because it is a real, tested hardware
@@ -217,18 +296,23 @@ func SetAllFansFullSpeed() error {
 	return writeIntFile(readDir+"/pwm1_enable", 0)
 }
 
-// HighTDPFanCurve returns an 8-point fan curve with a minimum PWM of 80%,
+// HighTDPFanCurve returns an 8-point fan curve with a minimum PWM of 50%,
 // suitable for sustained TDP above 75W. Users can replace this with a custom
 // curve as long as all PWM values stay at or above HighTDPMinPWM.
+//
+// The floor holds only while the APU is cool; from 60°C the curve climbs hard
+// and reaches 100% at 80°C, which is the range a machine actually sustaining
+// more than TDPMaxSafe watts lives in. Keeping the top of the ramp is what
+// makes the lower floor safe.
 func HighTDPFanCurve() []api.FanCurvePoint {
 	return []api.FanCurvePoint{
 		{Temp: 30, PWM: HighTDPMinPWM},
 		{Temp: 40, PWM: HighTDPMinPWM},
-		{Temp: 50, PWM: 215},
-		{Temp: 60, PWM: 225},
-		{Temp: 65, PWM: 235},
-		{Temp: 70, PWM: 240},
-		{Temp: 75, PWM: 250},
+		{Temp: 50, PWM: 140},
+		{Temp: 60, PWM: 165},
+		{Temp: 65, PWM: 190},
+		{Temp: 70, PWM: 215},
+		{Temp: 75, PWM: 235},
 		{Temp: 80, PWM: 255},
 	}
 }

--- a/internal/cli/fan_sysfs_test.go
+++ b/internal/cli/fan_sysfs_test.go
@@ -35,6 +35,7 @@ func TestFindFanHwmonPathMissingDir(t *testing.T) {
 func TestSetBothFanCurvesWritesBothFansAndEnablesCustom(t *testing.T) {
 	f := newFakeSysfs(t)
 	f.seedFanCurveFiles(t, 40, 100)
+	seedReadingsSentinel(t, f)
 
 	points := make([]api.FanCurvePoint, fanCurvePoints)
 	for i := range points {
@@ -52,13 +53,29 @@ func TestSetBothFanCurvesWritesBothFansAndEnablesCustom(t *testing.T) {
 				t.Errorf("fan%d point %d = %d:%d, want %d:%d", fan.index, i+1, gotTemp, gotPWM, p.Temp, p.PWM)
 			}
 		}
-		// Custom mode must be enabled on both the curve and readings devices.
+		// Custom mode must be enabled on the curve device...
 		if got := f.readInt(t, f.hwmon+"/pwm"+itoa(fan.index)+"_enable"); got != 1 {
 			t.Errorf("curve device fan%d pwm_enable = %d, want 1 (custom)", fan.index, got)
 		}
-		if got := f.readInt(t, f.hwmonRead+"/pwm"+itoa(fan.index)+"_enable"); got != 1 {
-			t.Errorf("readings device fan%d pwm_enable = %d, want 1 (custom)", fan.index, got)
+		// ...and the base "asus" device must be left untouched. Its
+		// pwm1_enable_store rejects mode 1 on the Z13 (fan_type SPEC83) and, where
+		// it is accepted, clears custom_fan_curves[*].enabled for every fan —
+		// undoing the curve that was just enabled. See issue #15.
+		if got := f.readInt(t, f.hwmonRead+"/pwm"+itoa(fan.index)+"_enable"); got != readingsSentinel {
+			t.Errorf("readings device fan%d pwm_enable = %d, want %d (untouched)", fan.index, got, readingsSentinel)
 		}
+	}
+}
+
+// readingsSentinel is written to the base "asus" device's pwm_enable files so a
+// test can tell "left alone" from "written with the same value".
+const readingsSentinel = 9
+
+// seedReadingsSentinel marks both readings-device pwm_enable files.
+func seedReadingsSentinel(t *testing.T, f *fakeSysfs) {
+	t.Helper()
+	for _, fan := range fanNames {
+		f.writeFile(t, f.hwmonRead+"/pwm"+itoa(fan.index)+"_enable", itoa(readingsSentinel))
 	}
 }
 
@@ -78,9 +95,10 @@ func TestSetBothFanCurvesErrorsWhenHwmonMissing(t *testing.T) {
 	}
 }
 
-func TestResetAllFanCurvesSetsAutoOnBothDevices(t *testing.T) {
+func TestResetAllFanCurvesSetsAutoOnCurveDeviceOnly(t *testing.T) {
 	f := newFakeSysfs(t)
 	f.seedFanCurveFiles(t, 40, 100)
+	seedReadingsSentinel(t, f)
 
 	// Put both fans in custom mode first so the reset is observable.
 	if err := setAllFanModes(1); err != nil {
@@ -93,9 +111,96 @@ func TestResetAllFanCurvesSetsAutoOnBothDevices(t *testing.T) {
 		if got := f.readInt(t, f.hwmon+"/pwm"+itoa(fan.index)+"_enable"); got != 2 {
 			t.Errorf("curve device fan%d pwm_enable = %d, want 2 (auto)", fan.index, got)
 		}
-		if got := f.readInt(t, f.hwmonRead+"/pwm"+itoa(fan.index)+"_enable"); got != 2 {
-			t.Errorf("readings device fan%d pwm_enable = %d, want 2 (auto)", fan.index, got)
+		if got := f.readInt(t, f.hwmonRead+"/pwm"+itoa(fan.index)+"_enable"); got != readingsSentinel {
+			t.Errorf("readings device fan%d pwm_enable = %d, want %d (untouched)", fan.index, got, readingsSentinel)
 		}
+	}
+}
+
+// TestSetFanModeLeavesReadingsDeviceAlone is the direct guard on the mode-1/2
+// path: nothing but the curve device may be written, because the base device's
+// store handler clears the driver's custom-curve enabled flag as a side effect.
+func TestSetFanModeLeavesReadingsDeviceAlone(t *testing.T) {
+	for _, mode := range []int{1, 2} {
+		f := newFakeSysfs(t)
+		f.seedFanCurveFiles(t, 40, 100)
+		seedReadingsSentinel(t, f)
+
+		if err := setFanMode(1, mode); err != nil {
+			t.Fatalf("setFanMode(1, %d) = %v, want nil", mode, err)
+		}
+		if got := f.readInt(t, f.hwmon+"/pwm1_enable"); got != mode {
+			t.Errorf("curve device pwm1_enable = %d, want %d", got, mode)
+		}
+		if got := f.readInt(t, f.hwmonRead+"/pwm1_enable"); got != readingsSentinel {
+			t.Errorf("readings device pwm1_enable = %d, want %d (untouched)", got, readingsSentinel)
+		}
+	}
+}
+
+// TestSetBothFanCurvesFailsWhenCurveDoesNotStick is the regression test for
+// issue #15. The kernel accepts the pwm_enable write and then leaves the mode at
+// auto — which is what a concurrent platform_profile write produces — and the
+// caller must find out rather than being told the curve was applied.
+func TestSetBothFanCurvesFailsWhenCurveDoesNotStick(t *testing.T) {
+	f := newFakeSysfs(t)
+	f.seedFanCurveFiles(t, 40, 100) // seeds pwm_enable = 2 (auto)
+
+	orig := fanWriteInt
+	fanWriteInt = func(string, int) error { return nil } // accepted, no effect
+	t.Cleanup(func() { fanWriteInt = orig })
+
+	points := make([]api.FanCurvePoint, fanCurvePoints)
+	for i := range points {
+		points[i] = api.FanCurvePoint{Temp: 30 + i*5, PWM: 50 + i*20}
+	}
+	err := SetBothFanCurves(points)
+	if err == nil {
+		t.Fatal("SetBothFanCurves() = nil, want an error when the kernel does not honour the curve")
+	}
+	if !strings.Contains(err.Error(), "pwm1_enable") {
+		t.Errorf("error %q does not name the attribute that proved it", err)
+	}
+	if got := f.readInt(t, f.hwmon+"/pwm1_enable"); got != 2 {
+		t.Fatalf("test setup: curve device pwm1_enable = %d, want 2", got)
+	}
+}
+
+func TestVerifyFanCurveActive(t *testing.T) {
+	cases := []struct {
+		name    string
+		modes   [fanCount]string // "" means do not create the file
+		wantErr bool
+	}{
+		{"both custom", [fanCount]string{"1", "1"}, false},
+		{"fan1 dropped to auto", [fanCount]string{"2", "1"}, true},
+		{"fan2 dropped to auto", [fanCount]string{"1", "2"}, true},
+		{"full speed is not custom", [fanCount]string{"0", "1"}, true},
+		// Unverifiable is not the same as failed: a SKU exposing only the CPU
+		// curve must keep working, floor and all.
+		{"fan2 missing", [fanCount]string{"1", ""}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeSysfs(t)
+			for i, fan := range fanNames {
+				if tc.modes[i] == "" {
+					continue
+				}
+				f.writeFile(t, f.hwmon+"/pwm"+itoa(fan.index)+"_enable", tc.modes[i])
+			}
+			err := VerifyFanCurveActive()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("VerifyFanCurveActive() = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyFanCurveActiveErrorsWhenHwmonMissing(t *testing.T) {
+	swap(t, &sysHwmonDir, t.TempDir())
+	if err := VerifyFanCurveActive(); err == nil {
+		t.Error("VerifyFanCurveActive() = nil, want an error when the hwmon device is absent")
 	}
 }
 

--- a/internal/cli/tdp.go
+++ b/internal/cli/tdp.go
@@ -169,6 +169,14 @@ func SetTDP(watts, pl1, pl2, pl3 int) error {
 // floor is the exact condition HighTDPFanCurve exists to prevent, so failing
 // closed is the only safe outcome.
 //
+// "Fails" now includes the kernel accepting the write and then dropping the
+// curve: SetBothFanCurves reads pwm_enable back, so a floor lost to a
+// concurrent platform_profile write is a refusal rather than a false success.
+// This function only guarantees the floor at the moment the limit is raised —
+// keeping it in force afterwards is the reconcile watcher's job
+// (internal/daemon/reconcile.go), since a later profile write would otherwise
+// return the fans to firmware auto while the PPT stays high.
+//
 // This is the single entry point for every path that applies a custom TDP —
 // the socket handler, the "custom" profile recall, daemon startup, resume, and
 // the no-daemon CLI path. They previously enforced the floor four different
@@ -202,7 +210,7 @@ func CheckFanCurveFloor(profile string, points []api.FanCurvePoint) error {
 	}
 	for _, p := range points {
 		if p.PWM < HighTDPMinPWM {
-			return fmt.Errorf("PWM %d at %d°C is below minimum %d (80%%) required when sustained TDP is above %dW",
+			return fmt.Errorf("PWM %d at %d°C is below minimum %d (50%%) required when sustained TDP is above %dW",
 				p.PWM, p.Temp, HighTDPMinPWM, TDPMaxSafe)
 		}
 	}

--- a/internal/cli/tdp_test.go
+++ b/internal/cli/tdp_test.go
@@ -152,7 +152,7 @@ func TestStockProfilePPTSanity(t *testing.T) {
 }
 
 // TestApplyTDPSafely is the regression guard for the thermal-floor cluster: the
-// four paths that apply a custom TDP each enforced the 80% fan floor
+// four paths that apply a custom TDP each enforced the 50% fan floor
 // differently, and one of them raised power before raising the fans and threw
 // the fan error away. They now all go through ApplyTDPSafely, which must fail
 // closed.
@@ -211,6 +211,34 @@ func TestApplyTDPSafely(t *testing.T) {
 		err := ApplyTDPSafely(high)
 		if err == nil {
 			t.Fatal("ApplyTDPSafely() = nil, want an error when the fan curve cannot be written")
+		}
+
+		got, readErr := ReadAllPPT()
+		if readErr != nil {
+			t.Fatalf("ReadAllPPT() = %v, want nil", readErr)
+		}
+		if got != baseline {
+			t.Errorf("PPT = %+v, want the untouched baseline %+v — an unsafe TDP was applied without the fan floor", got, baseline)
+		}
+	})
+
+	// The other half of failing closed: the write is accepted but the kernel
+	// does not keep the mode, which is what a concurrent platform_profile write
+	// produces. Before the readback in SetBothFanCurves this looked like success
+	// and the machine ran above the safe sustained max with no floor at all.
+	t.Run("refuses the TDP when the fan curve does not stick", func(t *testing.T) {
+		f := newFakeSysfs(t)
+		f.seedFanCurveFiles(t, 40, 50) // pwm_enable = 2 (auto)
+		baseline := StockProfilePPT["balanced"]
+		if err := SetTDPState(baseline); err != nil {
+			t.Fatalf("SetTDPState(baseline) = %v, want nil", err)
+		}
+		orig := fanWriteInt
+		fanWriteInt = func(string, int) error { return nil } // accepted, no effect
+		t.Cleanup(func() { fanWriteInt = orig })
+
+		if err := ApplyTDPSafely(high); err == nil {
+			t.Fatal("ApplyTDPSafely() = nil, want an error when the kernel drops the fan curve")
 		}
 
 		got, readErr := ReadAllPPT()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -35,6 +35,15 @@ import (
 
 // Daemon holds the runtime state for the long-running z13ctl process.
 type Daemon struct {
+	// hwMu serializes hardware *mutation sequences* — fan mode, PPT, profile —
+	// against each other. d.mu guards state only, and every mutating handler
+	// deliberately does its hardware I/O outside it, so without hwMu the
+	// reconcile watcher could interleave its SetBothFanCurves with a handler's
+	// ResetAllFanCurves and the fans would keep whichever mode landed last.
+	//
+	// Lock order is hwMu then d.mu. Never acquire hwMu while holding d.mu.
+	hwMu sync.Mutex
+
 	mu    sync.Mutex
 	dev   *hid.Device // nil if no HID device was found at startup
 	state api.State
@@ -128,7 +137,7 @@ func Run(ctx context.Context, watchBtn bool) error {
 			}
 		}
 		if t := d.state.TDP; t != nil {
-			// ApplyTDPSafely raises the fans to the 80% floor first when the
+			// ApplyTDPSafely raises the fans to the 50% floor first when the
 			// sustained limit exceeds the safe max, and declines to apply the
 			// TDP at all if that fails — better to boot at the existing limits
 			// than above the safe sustained max with no thermal floor.
@@ -157,6 +166,10 @@ func Run(ctx context.Context, watchBtn bool) error {
 	go d.watchResume(ctx)
 
 	go d.watchHotplug(ctx)
+
+	// State-driven, so it is a no-op on a machine that never uses the custom
+	// profile; register it unconditionally.
+	go d.watchReconcile(ctx)
 
 	ln, err := d.getListener()
 	if err != nil {

--- a/internal/daemon/reconcile.go
+++ b/internal/daemon/reconcile.go
@@ -1,0 +1,245 @@
+package daemon
+
+// reconcile.go — puts the custom fan curve (and the high-TDP fan floor) back
+// after something else takes it away.
+//
+// The asus-wmi driver disables custom fan curves on every platform_profile
+// write: throttle_thermal_policy_write() ends by clearing
+// custom_fan_curves[*].enabled for each fan, and fan_curve_write() then returns
+// early on !enabled. Nothing is reported to the process that set the curve. On
+// a GNOME desktop, power-profiles-daemon writes platform_profile on every
+// AC/battery transition and on any PPD hold, so a curve set by z13ctl stops
+// working minutes later for no visible reason — issue #15. Fn+F5, asusctl,
+// tuned and a module reload all do the same thing.
+//
+// The watcher polls the curve device's pwm_enable rather than
+// platform_profile: fan_curve_enable_show() returns the driver's cached
+// enabled flag, so it is ground truth for "is the curve live" and it catches
+// every cause rather than only the one we predicted. platform_profile is read
+// in the same tick for the log line alone.
+//
+// It never writes platform_profile. Profile ownership stays with the desktop;
+// putting z13ctl in a write-fight with power-profiles-daemon over every AC
+// transition would be worse than the bug. It also acts only while daemon state
+// says the profile is "custom", so a deliberate switch to a stock profile is
+// left alone by construction.
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+// reconcilePollInterval is how often watchReconcile compares hardware against
+// the daemon's saved custom state. Both reads it makes are served from driver
+// caches (no WMI call), so the cost is negligible; 2 s matches watchHotplug.
+const reconcilePollInterval = 2 * time.Second
+
+// reconcileQuietAfter is how many consecutive failed restorations are logged
+// before the watcher goes quiet. A restore that can never succeed — revoked
+// permissions, an unbound driver — would otherwise fill the journal forever.
+const reconcileQuietAfter = 3
+
+// reconcileObs is one observation: what daemon state says should be in force,
+// and what the hardware currently reports.
+type reconcileObs struct {
+	Profile   string              // effective profile from daemon state
+	WantCurve []api.FanCurvePoint // saved custom curve; nil if none
+	WantTDP   *api.TDPState       // saved custom TDP; nil if none
+	CurveMode int                 // curve device pwm1_enable; -1 if unreadable
+	PL1       int                 // effective sustained limit in watts; -1 if unreadable
+	ProfileHW string              // platform_profile, for logging only
+}
+
+// reconcileAction is what a tick decided to put back. A zero value means
+// "leave the hardware alone", which is the common case.
+type reconcileAction struct {
+	Curve  []api.FanCurvePoint
+	TDP    *api.TDPState
+	Reason string
+}
+
+// none reports whether the action would touch anything.
+func (a reconcileAction) none() bool { return a.Curve == nil && a.TDP == nil }
+
+// reconcileState is the latched watcher state carried between ticks.
+type reconcileState struct {
+	failures int    // consecutive unsuccessful restorations
+	quiet    bool   // stop logging repeated failures
+	lastHW   string // last observed platform_profile
+}
+
+// reconcileTick decides what to restore from one observation. It is pure — no
+// sysfs, no locks, no logging — so every branch below is unit-testable without
+// hardware, which is the only way daemon-side logic can be tested in this
+// project (internal/cli's path vars are unexported, so a daemon test that
+// reaches hardware writes the developer's actual machine).
+func reconcileTick(prev reconcileState, obs reconcileObs) (reconcileState, reconcileAction) {
+	st := prev
+	st.lastHW = obs.ProfileHW
+
+	// Only "custom" means the daemon is claiming ownership of fans and PPT.
+	// Every route to a stock profile — handleProfile, handleTDPReset,
+	// handleFanCurveReset — updates state first, so this is what keeps the
+	// watcher from fighting a legitimate profile switch.
+	if obs.Profile != "custom" {
+		st.failures = 0
+		st.quiet = false
+		return st, reconcileAction{}
+	}
+
+	var act reconcileAction
+
+	switch {
+	case obs.CurveMode == -1:
+		// Unreadable: never act on an unknown.
+	case obs.CurveMode == 1:
+		// Curve is live.
+	case obs.CurveMode == 0:
+		// Someone deliberately forced full speed. That is more cooling than
+		// any curve we would write, so leave it.
+	case obs.WantCurve != nil && obs.PL1 > cli.TDPMaxSafe && curveBelowFloor(obs.WantCurve):
+		// The saved curve is not always safe to restore. CheckFanCurveFloor
+		// only vets a curve against the limit in force when it is *saved*, and
+		// raising the TDP afterwards does not rewrite it — handleTDP applies
+		// HighTDPFanCurve to hardware but deliberately keeps the user's curve
+		// in state for when the limit comes back down. Restoring it here would
+		// undo the floor at exactly the moment it is needed.
+		act.Curve = cli.HighTDPFanCurve()
+		act.Reason = "fan curve was disabled and the saved curve is below the high-TDP floor"
+	case obs.WantCurve != nil:
+		act.Curve = obs.WantCurve
+		act.Reason = "saved custom fan curve was disabled"
+	case obs.PL1 > cli.TDPMaxSafe:
+		// No saved curve, but the sustained limit still requires the floor.
+		// This is the half of ApplyTDPSafely's fail-closed guard that was
+		// missing: the floor was written once and could then be silently
+		// dropped while the PPT stayed high.
+		act.Curve = cli.HighTDPFanCurve()
+		act.Reason = "high-TDP fan floor was released while the limit is still in force"
+	}
+
+	// PPT is defended against third parties (asusctl, ryzenadj), not against
+	// the kernel: a platform_profile write does not reset the ppt_* values.
+	if obs.WantTDP != nil && obs.PL1 != -1 && obs.PL1 != obs.WantTDP.PL1SPL {
+		act.TDP = obs.WantTDP
+		if act.Reason == "" {
+			act.Reason = "sustained TDP no longer matches the saved custom value"
+		}
+	}
+
+	if act.none() {
+		st.failures = 0
+		st.quiet = false
+	}
+	return st, act
+}
+
+// curveBelowFloor reports whether any point sits under the PWM floor that a
+// sustained limit above cli.TDPMaxSafe requires.
+func curveBelowFloor(points []api.FanCurvePoint) bool {
+	for _, p := range points {
+		if p.PWM < cli.HighTDPMinPWM {
+			return true
+		}
+	}
+	return false
+}
+
+// watchReconcile runs until ctx is done, restoring the custom fan curve and
+// high-TDP floor whenever something else removes them.
+func (d *Daemon) watchReconcile(ctx context.Context) {
+	var st reconcileState
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(reconcilePollInterval):
+		}
+		st = d.reconcileOnce(st)
+	}
+}
+
+// reconcileOnce performs one observe-decide-apply cycle and returns the new
+// latched state. It is the only part of the watcher that touches hardware.
+func (d *Daemon) reconcileOnce(prev reconcileState) reconcileState {
+	// hwMu before d.mu, always: this sequence writes the same sysfs attributes
+	// the socket handlers do, and interleaving with them would leave the fans
+	// in whichever mode happened to be written last.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	s := cloneState(d.state) // must clone: FanCurve.Points and TDP alias live state
+	d.mu.Unlock()
+
+	obs := reconcileObs{
+		Profile:   s.Profile,
+		CurveMode: -1,
+		PL1:       -1,
+	}
+	if s.FanCurve != nil && s.FanCurve.Mode == 1 && len(s.FanCurve.Points) == 8 {
+		obs.WantCurve = s.FanCurve.Points
+	}
+	obs.WantTDP = s.TDP
+
+	// Cheap enough to read unconditionally, and reading them even when the
+	// profile is stock keeps lastHW meaningful for the log line.
+	if modes, err := cli.ReadFanCurveModes(); err == nil {
+		obs.CurveMode = modes[0]
+	}
+	if tdp, err := cli.ReadEffectivePPT(d.effectiveProfile()); err == nil {
+		obs.PL1 = tdp.PL1SPL
+	}
+	obs.ProfileHW = readProfileFromSysfs()
+
+	st, act := reconcileTick(prev, obs)
+	if act.none() {
+		return st
+	}
+
+	logf := slog.Warn
+	if st.quiet {
+		logf = slog.Debug
+	}
+	logf("reconciling custom thermal settings",
+		"reason", act.Reason,
+		"platform_profile", obs.ProfileHW,
+		"pwm_enable", obs.CurveMode)
+
+	ok := true
+	if act.Curve != nil {
+		if err := cli.SetBothFanCurves(act.Curve); err != nil {
+			ok = false
+			if !st.quiet {
+				slog.Warn("failed to re-apply fan curve", "err", err)
+			}
+		}
+	}
+	if act.TDP != nil {
+		if err := cli.ApplyTDPSafely(*act.TDP); err != nil {
+			ok = false
+			if !st.quiet {
+				slog.Warn("failed to re-apply TDP", "err", err)
+			}
+		}
+	}
+
+	if ok {
+		st.failures = 0
+		st.quiet = false
+		return st
+	}
+	st.failures++
+	if st.failures >= reconcileQuietAfter {
+		if !st.quiet {
+			slog.Warn("reconciliation keeps failing; further attempts will not be logged",
+				"attempts", st.failures)
+		}
+		st.quiet = true
+	}
+	return st
+}

--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -1,0 +1,210 @@
+package daemon
+
+// reconcile_test.go — decision coverage for the watcher that puts a custom fan
+// curve back after the kernel drops it.
+//
+// Every case here goes through the pure reconcileTick. That is deliberate:
+// internal/cli's sysfs path vars are unexported, so a daemon test that reached
+// the apply path would write the developer's actual fan hardware.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+func curve(pwm int) []api.FanCurvePoint {
+	points := make([]api.FanCurvePoint, 8)
+	for i := range points {
+		points[i] = api.FanCurvePoint{Temp: 30 + i*5, PWM: pwm}
+	}
+	return points
+}
+
+func TestReconcileTick(t *testing.T) {
+	saved := curve(120)
+	floorTDP := &api.TDPState{PL1SPL: 90, PL2SPPT: 90, FPPT: 90}
+
+	tests := []struct {
+		name      string
+		obs       reconcileObs
+		wantCurve bool
+		wantFloor bool // the restored curve must be HighTDPFanCurve
+		wantTDP   bool
+	}{
+		{
+			name: "stock profile is left alone even with hardware in auto",
+			obs:  reconcileObs{Profile: "balanced", WantCurve: saved, CurveMode: 2, PL1: 35},
+		},
+		{
+			name: "empty profile is not custom",
+			obs:  reconcileObs{Profile: "", WantCurve: saved, CurveMode: 2, PL1: 35},
+		},
+		{
+			name: "curve still live: nothing to do",
+			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 1, PL1: 35},
+		},
+		{
+			name: "unreadable mode: never act on an unknown",
+			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: -1, PL1: 35},
+		},
+		{
+			name: "full speed is more cooling than we would write",
+			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 0, PL1: 90},
+		},
+		{
+			name:      "dropped to auto with a saved curve",
+			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: 35},
+			wantCurve: true,
+		},
+		{
+			name:      "unreadable PPT does not block restoring a saved curve",
+			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: -1},
+			wantCurve: true,
+		},
+		{
+			name:      "no saved curve but the high-TDP floor is required",
+			obs:       reconcileObs{Profile: "custom", CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			wantCurve: true,
+			wantFloor: true,
+		},
+		{
+			// Caught on hardware: the saved curve is only vetted against the
+			// limit in force when it is saved, and raising the TDP afterwards
+			// leaves a sub-floor curve in state. Restoring it would undo the
+			// floor at the moment it is needed.
+			name:      "saved curve below the floor while the limit is high",
+			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			wantCurve: true,
+			wantFloor: true,
+		},
+		{
+			name:      "saved curve already meets the floor",
+			obs:       reconcileObs{Profile: "custom", WantCurve: curve(cli.HighTDPMinPWM), CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			wantCurve: true,
+			wantFloor: true, // its own points are at the floor
+		},
+		{
+			name: "no saved curve and the limit is safe",
+			obs:  reconcileObs{Profile: "custom", CurveMode: 2, PL1: cli.TDPMaxSafe},
+		},
+		{
+			name: "no saved curve and PPT unreadable",
+			obs:  reconcileObs{Profile: "custom", CurveMode: 2, PL1: -1},
+		},
+		{
+			name:    "PPT drifted from the saved custom value",
+			obs:     reconcileObs{Profile: "custom", CurveMode: 1, PL1: 35, WantTDP: floorTDP},
+			wantTDP: true,
+		},
+		{
+			name: "PPT matches the saved value",
+			obs:  reconcileObs{Profile: "custom", CurveMode: 1, PL1: 90, WantTDP: floorTDP},
+		},
+		{
+			name: "unreadable PPT is not a TDP mismatch",
+			obs:  reconcileObs{Profile: "custom", CurveMode: 1, PL1: -1, WantTDP: floorTDP},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, act := reconcileTick(reconcileState{}, tt.obs)
+
+			if got := act.Curve != nil; got != tt.wantCurve {
+				t.Errorf("restored a curve = %v, want %v", got, tt.wantCurve)
+			}
+			if got := act.TDP != nil; got != tt.wantTDP {
+				t.Errorf("restored TDP = %v, want %v", got, tt.wantTDP)
+			}
+			if act.Curve != nil {
+				if tt.wantFloor {
+					if act.Curve[0].PWM != cli.HighTDPMinPWM {
+						t.Errorf("restored curve starts at PWM %d, want the %d floor", act.Curve[0].PWM, cli.HighTDPMinPWM)
+					}
+				} else if act.Curve[0].PWM != saved[0].PWM {
+					t.Errorf("restored curve starts at PWM %d, want the saved %d", act.Curve[0].PWM, saved[0].PWM)
+				}
+				if act.Reason == "" {
+					t.Error("an action was returned with no reason to log")
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileTickQuietsAfterRepeatedFailure covers the latch that keeps a
+// restore which can never succeed — revoked permissions, an unbound driver —
+// from writing a warning to the journal every two seconds forever.
+func TestReconcileTickQuietsAfterRepeatedFailure(t *testing.T) {
+	obs := reconcileObs{Profile: "custom", WantCurve: curve(120), CurveMode: 2, PL1: 35}
+
+	// The loop increments failures itself; the tick must not clear them while
+	// the hardware still disagrees.
+	st := reconcileState{failures: reconcileQuietAfter, quiet: true}
+	st, act := reconcileTick(st, obs)
+	if act.none() {
+		t.Fatal("tick stopped acting once quiet; it must keep restoring, only stop logging")
+	}
+	if !st.quiet {
+		t.Error("quiet latch was cleared while the curve was still not live")
+	}
+
+	// A tick with nothing to do clears the latch, so the next real failure is
+	// logged again.
+	st, act = reconcileTick(st, reconcileObs{Profile: "custom", CurveMode: 1, PL1: 35})
+	if !act.none() {
+		t.Fatalf("tick acted on a live curve: %+v", act)
+	}
+	if st.quiet || st.failures != 0 {
+		t.Errorf("state after a clean tick = %+v, want failures 0 and quiet false", st)
+	}
+}
+
+func TestReconcileTickTracksProfileForLogging(t *testing.T) {
+	st, _ := reconcileTick(reconcileState{lastHW: "performance"},
+		reconcileObs{Profile: "custom", CurveMode: 1, ProfileHW: "balanced"})
+	if st.lastHW != "balanced" {
+		t.Errorf("lastHW = %q, want \"balanced\"", st.lastHW)
+	}
+}
+
+// TestReconcileOnceIsRaceFree guards the aliasing hazard the watcher adds: it
+// reads state.FanCurve.Points and state.TDP, which handlers mutate under d.mu.
+// Run under -race.
+//
+// The daemon state deliberately holds a stock profile: reconcileTick returns no
+// action for it whatever the hardware reports, so this exercises the snapshot
+// and locking without any path to a sysfs write.
+func TestReconcileOnceIsRaceFree(t *testing.T) {
+	d := &Daemon{state: sampleState()}
+	d.state.Profile = "balanced"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		var st reconcileState
+		for range 200 {
+			st = d.reconcileOnce(st)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range 200 {
+			d.mu.Lock()
+			d.state.FanCurve.Points[0].PWM = i % 256
+			d.state.TDP.PL1SPL = 20 + i%40
+			d.mu.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	// Guard the premise: if the profile were "custom", the ticks above would
+	// have reached the apply path and written the machine's real fan hardware.
+	if d.state.Profile != "balanced" {
+		t.Fatalf("state.Profile = %q, want \"balanced\" — this test must never reach the apply path", d.state.Profile)
+	}
+}

--- a/internal/daemon/resume.go
+++ b/internal/daemon/resume.go
@@ -80,6 +80,11 @@ func (d *Daemon) watchResume(ctx context.Context) {
 // restoreVolatileState reapplies all settings that are lost on sleep/resume:
 // lighting, fan curves, TDP, and Curve Optimizer offsets.
 func (d *Daemon) restoreVolatileState() {
+	// hwMu before d.mu: the fan/TDP block below writes the same attributes the
+	// socket handlers and the reconcile watcher do.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
 	// Both d.dev and d.state are guarded by d.mu, and applyLightingState reads
 	// them directly, so hold the lock across it — the same discipline the socket
 	// handlers use. cloneState is required because the plain struct copy would
@@ -109,7 +114,7 @@ func (d *Daemon) restoreVolatileState() {
 		}
 	}
 
-	// Restore TDP. ApplyTDPSafely raises the fans to the 80% floor first when the
+	// Restore TDP. ApplyTDPSafely raises the fans to the 50% floor first when the
 	// sustained limit exceeds the safe max, and declines to apply the TDP at all
 	// if that fails.
 	if t := state.TDP; t != nil {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -360,35 +360,50 @@ func (d *Daemon) handleProfile(req request) response {
 
 	profile := strings.ToLower(req.Set)
 
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
 	// "custom" is a virtual profile: re-apply saved fan curve + TDP + UV.
 	if profile == "custom" {
+		// Snapshot under d.mu, then do the hardware work unlocked. Holding d.mu
+		// across cli.* calls — as this branch used to — takes d.mu before hwMu
+		// and inverts the lock order the rest of the daemon follows.
 		d.mu.Lock()
 		if d.state.FanCurve == nil && d.state.TDP == nil && d.state.Undervolt == nil {
 			d.mu.Unlock()
 			return response{OK: false, Error: "no custom settings saved; set fan curve, TDP, or undervolt first"}
 		}
 		d.state.Profile = "custom"
+		saved := cloneState(d.state)
+		d.mu.Unlock()
+
 		// Re-apply saved fan curve to both fans.
-		if fc := d.state.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
+		if fc := saved.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
 			if err := cli.SetBothFanCurves(fc.Points); err != nil {
 				slog.Warn("failed to reapply fan curve", "err", err)
 			}
 		}
-		// Re-apply saved TDP. ApplyTDPSafely raises the fans to the 80% floor
+		// Re-apply saved TDP. ApplyTDPSafely raises the fans to the 50% floor
 		// before raising power (this branch used to do it the other way round,
 		// and discarded the fan error) and refuses the TDP if that write fails.
-		if t := d.state.TDP; t != nil {
+		if t := saved.TDP; t != nil {
 			if err := cli.ApplyTDPSafely(*t); err != nil {
 				slog.Warn("failed to reapply TDP", "err", err)
 			}
 		}
 		// Re-apply saved undervolt.
-		if uv := d.state.Undervolt; uv != nil && cli.SMUProbeUndervolt() {
+		uvActive := false
+		if uv := saved.Undervolt; uv != nil && cli.SMUProbeUndervolt() {
 			if err := cli.SetCurveOptimizer(uv.CPUCO); err != nil {
 				slog.Warn("failed to reapply undervolt", "err", err)
 			} else {
-				d.state.Undervolt.Active = true
+				uvActive = true
 			}
+		}
+
+		d.mu.Lock()
+		if uvActive && d.state.Undervolt != nil {
+			d.state.Undervolt.Active = true
 		}
 		s := cloneState(d.state)
 		d.mu.Unlock()
@@ -567,6 +582,8 @@ func (d *Daemon) handleFanCurve(req request) response {
 	if err != nil {
 		return response{OK: false, Error: "fancurve: " + err.Error()}
 	}
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
 	// Enforce the minimum PWM floor when sustained TDP exceeds the safe max.
 	// This reads hardware rather than the cached d.state.TDP, which can disagree
 	// with it — a TDP set while the daemon was down, or a reset state file — and
@@ -590,6 +607,8 @@ func (d *Daemon) handleFanCurve(req request) response {
 }
 
 func (d *Daemon) handleFanCurveReset() response {
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
 	// Firmware auto has no PWM floor, so releasing the fans while a high
 	// sustained TDP is still in force removes the very protection the high-TDP
 	// curve provides. "tdp --reset" is the way out — it lowers power first.
@@ -683,14 +702,17 @@ func (d *Daemon) handleTDP(req request) response {
 		}
 	}
 
-	// ApplyTDPSafely raises the fans to the 80% floor first when pl1 exceeds the
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	// ApplyTDPSafely raises the fans to the 50% floor first when pl1 exceeds the
 	// safe sustained max, and refuses to apply the TDP at all if that fails.
 	tdp := cli.TDPStateFor(watts, pl1, pl2, pl3)
 	if err := cli.ApplyTDPSafely(tdp); err != nil {
 		return response{OK: false, Error: "tdp: " + err.Error()}
 	}
 	if pl1 > cli.TDPMaxSafe {
-		slog.Warn("fans set to 80%+ curve for high TDP", "pl1", pl1)
+		slog.Warn("fans set to 50%+ curve for high TDP", "pl1", pl1)
 	}
 	slog.Info("tdp", "pl1", pl1, "pl2", pl2, "pl3", pl3)
 
@@ -719,9 +741,11 @@ func (d *Daemon) handleTDP(req request) response {
 }
 
 func (d *Daemon) handleTDPReset() response {
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
 	// Lower power first, then release the fans: balanced's sustained limit is
 	// below TDPMaxSafe, so by the time the fans drop to firmware auto the limit
-	// that required the 80% floor is gone. Doing it the other way round leaves a
+	// that required the 50% floor is gone. Doing it the other way round leaves a
 	// window at full power with no floor, and a failed profile switch would
 	// leave it that way. The firmware manages fan curves on a profile change but
 	// does not restore PPT, so restoreStockPPT has to be explicit.


### PR DESCRIPTION
Fixes #15.

## Problem

The `asus-wmi` driver disables custom fan curves on every `platform_profile`
write. `throttle_thermal_policy_write()` ends by clearing
`custom_fan_curves[*].enabled`, and `fan_curve_write()` then returns early on
`!enabled`. Nothing is reported to the process that set the curve, so the fans
return to the firmware curve while `fancurve --get` goes on listing the points.

On a GNOME desktop this fires routinely: `power-profiles-daemon` writes
`platform_profile` on every AC/battery transition and on any profile hold.
Fn+F5, `asusctl` and `tuned` do the same.

Reproduced on a GZ302EA before any change:

```
$ z13ctl fancurve --set "40:30%,50:40%,60:50%,70:60%,75:70%,80:80%,85:90%,90:100%"
Fan curves set for both fans (custom mode enabled)
$ cat /sys/class/hwmon/hwmon11/pwm1_enable
1
$ powerprofilesctl set performance
$ cat /sys/class/hwmon/hwmon11/pwm1_enable
2                # curve disabled, no error anywhere
```

The same gap made `ApplyTDPSafely` only half a guard: the 80% floor was written
once before raising PL1 above 75 W, and a later profile change released the fans
while the power limit stayed in force (the firmware does not re-apply PPT on a
profile write — #12).

## Changes

- `SetBothFanCurves` reads `pwm_enable` back (`VerifyFanCurveActive`) and returns
  an error instead of reporting success when the kernel drops the curve. An
  unreadable channel is deliberately not a failure, so a SKU exposing only the
  CPU curve keeps working.
- New `internal/daemon/reconcile.go`: polls the curve device's `pwm_enable` every
  2 s and re-applies the saved curve, or `HighTDPFanCurve` when the sustained
  limit still requires it. It watches the driver's enable flag rather than
  `platform_profile`, since `fan_curve_enable_show()` returns the cached flag and
  therefore catches every cause. It never writes `platform_profile`, and it is
  inert unless `state.Profile == "custom"`, so a deliberate stock switch is left
  alone.
- `setFanMode` no longer syncs modes 1/2 to the base `asus` hwmon device. That
  device is `fan_type` SPEC83 on the Z13 (mode 1 returns `EINVAL`) and its store
  handler clears the driver's custom-curve flag, so where the write is accepted
  it would undo the curve just enabled — a latent copy of this same bug.
- New `hwMu` serialises hardware mutation sequences (fan mode, PPT, profile);
  lock order is `hwMu` then `d.mu`. The `profile --set custom` branch no longer
  holds `d.mu` across `cli.*` calls.
- Fan floor for sustained TDP above 75 W lowered from 80% (204) to 50% (127)
  after user reports that 80% was loud enough to discourage using high TDP at
  all. `HighTDPFanCurve` still reaches 100% at 80 °C:

  | Temp | 30 | 40 | 50 | 60 | 65 | 70 | 75 | 80 °C |
  |------|----|----|----|----|----|----|----|-------|
  | old  | 204 | 204 | 215 | 225 | 235 | 240 | 250 | 255 |
  | new  | 127 | 127 | 140 | 165 | 190 | 215 | 235 | 255 |

## Testing

`make test`, `make lint` (both modules) and `mkdocs build --strict` pass.

New hermetic coverage: `SetBothFanCurves` failing when the curve does not stick
(the regression test for #15), `VerifyFanCurveActive` including the
unreadable-channel case, `ApplyTDPSafely` refusing the TDP when the floor is
accepted but not kept, a decision table over `reconcileTick`, and a `-race` guard
on `reconcileOnce` against concurrent state mutation. Two dry-run tests that
hardcoded `204` now reference the constant.

Verified on hardware (GZ302EA):

- profile change drops the curve, reconciler restores it within 2 s
- `profile --set balanced` leaves the fans on firmware auto and stays there
- 80 W sustained writes the floor curve; after a profile change the floor is back
  within 2 s with PL1 still 80
- sub-floor curve refused at high TDP; a curve at exactly 50% accepted
- with the base `asus` device made read-only, setting a curve still succeeds

A hardware run also caught a defect in the first version of the reconciler:
restoring a *saved* sub-floor curve while PL1 was above 75 W would have undone
the thermal floor. That path now restores `HighTDPFanCurve` instead.

## Notes for review

- Requires `systemctl --user restart z13ctl.service` after install for the
  watcher to start. The socket protocol and the `api` module are unchanged.
- The floor change relaxes a documented safety rule; anyone running `--force`
  above 75 W on v1.2.1 will find the machine quieter and warmer at light load.
- The other observation in #15 — "the CPU fan runs slower than the GPU fan" — is
  stock behaviour and is deliberately not addressed. The firmware commands the
  two fans differently by default (`gpu_fan` is 3–5 PWM higher at every point
  above 57 °C), and the fans differ physically, so they sit 1.3–4.1% apart even
  at an identical commanded PWM. Nothing in z13ctl causes or corrects that.
- Also measured: there is no per-profile RPM cap. 100% PWM gives ~7500 RPM under
  quiet, balanced and performance alike, so the ~6000 RPM ceiling in the report
  was the curve not being in effect.
- Draft release notes for v1.2.2 are in `release-notes.md` (gitignored, for
  `git tag -a -F`).
