### PR TITLE
feat: Named custom profiles and AC/battery profile autoswitching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,29 @@ contrib/
   to edit; absent/empty means the active one. `profile --set` now *rejects* a
   name that is neither a firmware profile nor a saved custom profile, where it
   used to forward any string to `platform_profile`.
+- **`subscribe`'s `events` list is honoured; it was ignored until v1.3.0.**
+  `addSubscriber` now records the set and `broadcast` filters on it. That was
+  invisible while `gui-toggle` was the only event, and became a live hazard the
+  moment a second one existed: a client that subscribed to `gui-toggle` and wrote
+  the obvious `for range ch { toggle() }` — reasonable when only one event
+  existed — would toggle its window on every power-source change. A subscriber
+  that did *not* want an event must survive the broadcast rather than being
+  pruned. Events are `gui-toggle`, `power-source` and `state-changed`
+  (`api/events.go`), and carry **no payload**: the name says what happened and
+  `get-state` answers with current truth, whereas a payload describes the moment
+  the event was queued. That is also why `api.Subscribe` keeps its
+  `<-chan string` signature — the payload was the only thing that wanted a
+  breaking change.
+- **Broadcast writes are deadline-bounded (`broadcastWriteTimeout`).** Events are
+  emitted from handlers holding `hwMu`, so an unbounded write to a subscriber
+  that stopped reading would block every hardware operation in the daemon behind
+  a socket buffer. A subscriber that cannot take a notification in time is
+  dropped.
+- **Every handler that mutates profile or thermal state calls `saveAndNotify`,
+  not `saveState`.** That is the funnel which keeps a new handler from silently
+  leaving clients showing stale values. Lighting handlers deliberately still call
+  `saveState` directly — a brightness slider drag would otherwise emit a burst of
+  events describing values the client just set.
 - **Streamed events must set `OK: true`.** `response.OK` has no `omitempty`, so
   `broadcast(response{Event: ...})` ships `{"ok":false,...}` on a perfectly good
   event. The Go client keys on the `event` field and never noticed, but the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Module path: `github.com/dahui/z13ctl`. Binary name: `z13ctl`. License: Apache 2
 ```
 api/                         Public client API submodule (github.com/dahui/z13ctl/api)
   go.mod                     Separate module; stdlib only; importable by z13gui and external tools
-  types.go                   State, LightingState, FanCurvePoint, FanCurveState, TDPState, UndervoltState (exported protocol types)
+  types.go                   State, LightingState, FanCurvePoint, FanCurveState, TDPState, UndervoltState,
+                             CustomProfile, AutoswitchState; IsCustomProfile/InCustomProfile/ActiveCustomProfile
   client.go                  SocketPath, Send*, Subscribe (all client functions)
   example_test.go            testable examples for all Send* and Subscribe functions
 main.go                      entry point
@@ -24,7 +25,8 @@ cmd/                         Cobra subcommands
   daemon.go                  start the daemon (z13ctl daemon)
   list.go                    list hidraw devices
   off.go                     turn lighting off
-  profile.go                 get/set performance profile (platform_profile sysfs); "custom" virtual profile
+  profile.go                 get/set profile; create/save-as/delete/list custom profiles
+  autoswitch.go              configure the AC/battery profile pair
   batterylimit.go            get/set battery charge limit (power_supply sysfs)
   bootsound.go               get/set POST boot sound (asus-armoury firmware-attributes)
   paneloverdrive.go          get/set panel refresh overdrive (asus-armoury firmware-attributes)
@@ -35,6 +37,7 @@ cmd/                         Cobra subcommands
   setup.go                   install udev rules; applySysfsPerms helper (HID, hwmon, PPT, firmware-attributes, ryzen_smu)
   setup_test.go              drift guard: generated vs packaged contrib/ artifacts
   undervolt_test.go          --set parse rejections (CLI/daemon parity; no SMU access)
+  autoswitch_test.go         flag-combination rejections; profile-name parity; --profile guards
 internal/
   aura/                      Aura HID protocol implementation
     aura.go                  Writer interface + Init/SetPower/SetBrightness/SetMode/Apply/TurnOff
@@ -44,10 +47,13 @@ internal/
     colors.go                named color table, ResolveColor, PrintColorList
     parse.go                 ParseColor, ParseBrightness
     sysfs.go                 FindProfilePath, SetProfile, FindBatteryThresholdPath, FindBootSoundPath, SetBootSound, FindPanelOverdrivePath, SetPanelOverdrive, FindAPUTemperaturePath, ReadAPUTemperature, FindBatteryCapacityPath
+    power.go                 FindACOnlinePath, OnACPower (Mains-only discovery), IsStockProfile, ValidateProfileName
+    power_test.go            mains discovery vs the decoy supplies; profile-name rules
     fan.go                   hwmon discovery, fan curve read/write (both fans), RPM read, mode control, ParseFanCurve, SetAllFansFullSpeed
     paths.go                 sysfs roots as vars (injectable by tests); see Testing
     tdp.go                   PPT helpers, safety constants, StockProfilePPT, ReadEffectivePPT, ReadAllPPT,
-                             SetTDP, SetTDPState, TDPStateFor, ApplyTDPSafely, CheckFanCurveFloor, CheckFanFloorRelease
+                             SetTDP, SetTDPState, TDPStateFor, ApplyTDPSafely, CheckFanCurveFloor/CheckCurveAgainstTDP,
+                             CheckFanFloorRelease/CheckFanFloorReleaseAt (the *At forms are pure, for inactive profiles)
     smu.go                   SMU sysfs communication: SMUAvailable, SMUProbeUndervolt, SendSMUCommand, response codes
     undervolt.go             Curve Optimizer commands: SetCurveOptimizer, ResetCurveOptimizer, ValidateCOValues, safety limits
     undervolt_test.go        encodeCOValue, ValidateCOValues, smuResponseError tests
@@ -57,7 +63,9 @@ internal/
     smu_test.go              SMU mailbox protocol + Curve Optimizer tests
     tdp_test.go              SetTDPState/SetTDP/StockProfilePPT/ReadEffectivePPT tests +
                              ApplyTDPSafely fan-floor refusal (the thermal-guard regression test)
-    dryrun.go                DryRunApply, DryRunOff, DryRunBrightness, DryRunProfile, DryRunBatteryLimit, DryRunBootSound, DryRunPanelOverdrive, DryRunFanCurve, DryRunFanCurveReset, DryRunTdp, DryRunTdpReset, DryRunUndervolt, DryRunUndervoltReset
+    dryrun.go                DryRunApply, DryRunOff, DryRunBrightness, DryRunProfile, DryRunProfileCreate/Save/Delete,
+                             DryRunAutoswitch, DryRunBatteryLimit, DryRunBootSound, DryRunPanelOverdrive, DryRunFanCurve,
+                             DryRunFanCurveReset, DryRunTdp, DryRunTdpReset, DryRunUndervolt, DryRunUndervoltReset
   daemon/                    long-running daemon (socket server, state, button watcher)
     daemon.go                Package doc, Daemon struct, Run(), getListener() (socket activation)
     state.go                 XDG state file persistence (uses api.State/api.LightingState)
@@ -66,11 +74,18 @@ internal/
     button_test.go           device discovery + read-loop filtering (fake evdev device)
     hotplug.go               detachable-keyboard reattach watcher (polls sysfs, reopens HID + restores lighting)
     reconcile.go             custom fan curve / high-TDP floor watcher; pure reconcileTick seam + reconcileOnce
+    profile.go               applyProfileLocked/applyCustomHW/applyStockHW, edit-target resolution,
+                             profile create/save/delete/list handlers
+    powersource.go           AC/battery autoswitch watcher; pure powerTick seam + powerSourceOnce;
+                             UPower nudge + sysfs poll; autoswitchTarget for the Run() startup case
+    powersource_test.go      powerTick decision table, settle window, charger flap (no hardware)
     reconcile_test.go        reconcileTick decision table (no hardware) + reconcileOnce race guard
     server.go                JSON request handler; handleConn(), dispatch(), command handlers, restoreStockPPT(), effectiveProfile()
     server_test.go           request validation + dispatch routing (no hardware access)
-    state_test.go            state persistence: round-trip, corrupt-file preservation, temp cleanup
-    clone_test.go            cloneState deep-copy, saveState race regression, broadcast wire shape
+    state_test.go            state persistence: round-trip, corrupt-file preservation, temp cleanup,
+                             legacy migration, reserved-name sanitisation
+    clone_test.go            cloneState deep-copy (incl. CustomProfiles), saveState race regression,
+                             broadcast wire shape, withLegacyProjection
     resume.go                DBus logind PrepareForSleep watcher; turns off lightbar on sleep, restores lighting + volatile state on resume
     client.go                Redirect comment only — client functions live in api/
   hid/
@@ -156,7 +171,10 @@ contrib/
   the grab is a compile error. Trade-off: the keypress also reaches the desktop,
   and a foreign exclusive grab now fails silently rather than logging EBUSY.
 - **Daemon socket protocol**: Newline-delimited JSON over Unix socket. All responses
-  are `{"ok":bool,...}`. CLI `--get` commands read sysfs directly (always ground truth).
+  are `{"ok":bool,...}`. CLI `--get` commands read sysfs directly (always ground
+  truth) — except `profile --get`, which asks the daemon first and falls back to
+  sysfs: `platform_profile` is never a custom profile name, so sysfs alone cannot
+  say which custom profile is running.
   GUI/Decky callers use the daemon socket for all operations including GET. Protocol:
   | Command | Request | Response field |
   |---|---|---|
@@ -180,8 +198,20 @@ contrib/
   | undervolt set | `{"cmd":"undervolt","set":"-20"}` | `ok` |
   | undervolt get | `{"cmd":"undervolt-get"}` | `ok`, `value` (JSON: `cpu_co`, `active`, `profile`) |
   | undervolt reset | `{"cmd":"undervolt-reset"}` | `ok` |
-  | full state | `{"cmd":"get-state"}` | `ok`, `state` (cached + sysfs + live temp/RPM + undervolt_available) |
+  | profile create | `{"cmd":"profile-create","set":"gaming"}` | `ok` |
+  | profile save-as | `{"cmd":"profile-save","set":"gaming"}` | `ok` |
+  | profile delete | `{"cmd":"profile-delete","set":"gaming"}` | `ok` |
+  | profile list | `{"cmd":"profile-list"}` | `ok`, `value` (JSON) |
+  | autoswitch set | `{"cmd":"autoswitch","enabled":true,"ac":"balanced","battery":"gaming"}` | `ok` |
+  | autoswitch get | `{"cmd":"autoswitch-get"}` | `ok`, `value` (JSON) |
+  | full state | `{"cmd":"get-state"}` | `ok`, `state` (cached + sysfs + live temp/RPM + undervolt_available + on_ac) |
   | subscribe | `{"cmd":"subscribe","events":["gui-toggle"]}` | `ok`, then streams `{"ok":true,"event":"gui-toggle"}` |
+
+  `fancurve`, `fancurve-reset`, `tdp`, `tdp-reset`, `undervolt` and
+  `undervolt-reset` take an optional `"profile"` field naming the custom profile
+  to edit; absent/empty means the active one. `profile --set` now *rejects* a
+  name that is neither a firmware profile nor a saved custom profile, where it
+  used to forward any string to `platform_profile`.
 - **Streamed events must set `OK: true`.** `response.OK` has no `omitempty`, so
   `broadcast(response{Event: ...})` ships `{"ok":false,...}` on a perfectly good
   event. The Go client keys on the `event` field and never noticed, but the
@@ -249,9 +279,21 @@ contrib/
   `fan_curve_enable_show()` returns the driver's cached `enabled`, making it
   ground truth and catching every cause rather than the one we predicted. It
   never writes `platform_profile` (that would be a write-fight with PPD over
-  every AC transition) and acts only while `state.Profile == "custom"`, so a
-  deliberate stock-profile switch is left alone by construction.
+  every AC transition) and acts only while the active profile is a custom one
+  (`obs.Custom`, from `state.ActiveCustomProfile()`), so a deliberate
+  firmware-profile switch is left alone by construction. Named profiles are
+  defended exactly as `custom` is; a reserved name never is.
 - **`hwMu` guards hardware mutation sequences; lock order is `hwMu` then `d.mu`.**
+  `applyProfileLocked` states this in its doc comment because it is the one
+  function both a socket handler and a watcher call: the caller holds `hwMu` and
+  must NOT hold `d.mu`, and nothing reached from it may call
+  `d.effectiveProfile()`, which takes `d.mu`. It also decides custom-ness and
+  snapshots the profile in a single `d.mu` critical section, closing the window
+  where a concurrent `profile-delete` could remove the entry between the two.
+  `d.state.Profile` is set *before* the hardware work, so the reconcile watcher
+  starts defending the fans during the apply and a half-failed apply self-heals
+  on the next tick.
+  
   `d.mu` guards state, and every mutating handler does its hardware I/O outside
   it, so nothing otherwise stops the reconcile watcher interleaving its
   `SetBothFanCurves` with `handleProfile`'s `ResetAllFanCurves` — the fans would
@@ -287,6 +329,14 @@ contrib/
   fans (`handleTDPReset`, the stock-profile branch, `cmd/tdp.go` reset), so the
   machine is never at a high limit with no floor. `internal/cli/tdp_test.go`
   guards this against the fake sysfs; the refusal case is the one that matters.
+- **Fan-floor checks read hardware for the *live* profile, and the profile's own
+  TDP for any other.** `CheckFanCurveFloor`/`CheckFanFloorRelease` go through
+  `ReadEffectivePPT`; their pure siblings `CheckCurveAgainstTDP` and
+  `CheckFanFloorReleaseAt` take a limit directly, which is what an inactive
+  profile needs — hardware says nothing about a profile that is not running. The
+  effect is a *stronger* invariant than before: a profile can never be stored in
+  a state that would be unsafe the moment it is activated, and `ApplyTDPSafely`
+  still fails closed at activation.
 - **Fan-floor checks read hardware, not cached state.** `cli.CheckFanCurveFloor`
   and `cli.CheckFanFloorRelease` both take the *effective* profile and go through
   `ReadEffectivePPT`. `handleFanCurve` used to gate on `d.state.TDP`, which
@@ -338,6 +388,11 @@ contrib/
   `Undervolt.Active` still true while the daemon reported a stock profile — the
   same "custom setting leaks into a stock profile" defect as #12. Saved values
   are still preserved for recall; only `Active` and the hardware are reset.
+  `setUndervoltActive(state, false)` stamps every saved profile, since CO is
+  global hardware and at most one profile's offset can be applied. `Active` is
+  set true in exactly one place — `applyCustomHW`, and only when the SMU write
+  succeeded — so a profile copied while CO was live never claims to be applied
+  before anything was written.
 - **A corrupt state file is preserved, not silently replaced.** `loadState`
   renames an unparseable `state.json` to `state.json.corrupt` and logs before
   returning defaults; the next `saveState` would otherwise overwrite it, taking
@@ -353,13 +408,138 @@ contrib/
   (`0xFF`) for an all-zero primary colour, matching g-helper, so the firmware
   picks a colour. `off` / `--brightness off` is how you get no light. Documented
   in `docs/commands.md` and the `--color` flag help.
-- **Custom profile**: `profile --set custom` is a virtual profile that re-applies
-  saved fan curves and TDP from daemon state. It does NOT write to `platform_profile`
-  — the underlying hardware profile stays as-is. Setting any custom curve or TDP
-  implicitly sets profile to "custom". Switching to a stock profile (quiet/balanced/
-  performance) resets fan hardware to auto and writes that profile's `StockProfilePPT`
-  row to hardware, but preserves custom settings in state for later recall.
-  `profile --set custom` returns an error if no custom fan curves or TDP have been saved.
+- **Custom profiles are named records; `state.CustomProfiles` is the only
+  in-memory truth.** A custom profile is a `CustomProfile{Name, FanCurve, TDP,
+  Undervolt}` — per-subsystem *pointers*, so `nil` means "this profile does not
+  control that subsystem" and a new subsystem (GPU PPT, dynamic boost) is an
+  additive field that leaves old profiles loadable. None of them writes
+  `platform_profile`; the firmware profile underneath stays as-is.
+  `api.State.FanCurve/TDP/Undervolt` still exist but are a **projection**, filled
+  in only by `withLegacyProjection` at the two serialization boundaries
+  (`get-state` and `saveState`) so z13gui and the Decky plugin keep working. The
+  source is the active custom profile, or `custom` when a firmware profile is
+  active — i.e. whatever a bare `undervolt --set` edits and `profile --set custom`
+  recalls. Projecting *nothing* on a firmware profile looks tidier and is a
+  regression on both sides: a GUI showing "saved undervolt, not active" loses the
+  value it displays, and a downgrade taken while on `balanced` writes those
+  settings away entirely. `loadState` clears them after migrating, so nothing inside
+  the daemon can read the stale copy instead of the map; internal readers go
+  through `state.ActiveCustomProfile()`. Any new pointer/slice/map on `api.State`
+  must also be added to `cloneState` — `clone_test.go` under `-race` is the only
+  thing that catches a shallow copy of the profile map, and each entry needs a
+  copy of its own (three pointers and a slice), not just a new map header.
+- **The active profile is the default edit target; `--profile` overrides it.**
+  `fancurve|tdp|undervolt --set` with no `--profile` edits the profile you are
+  running, creating and activating `custom` when a firmware profile is active —
+  exactly the pre-existing behaviour, so no existing invocation changes meaning.
+  There is no working slot and no save step: the edit lands in the profile and
+  persists immediately. `--profile <name>` edits a profile that is *not* running,
+  stores only, and writes no hardware. That is not a convenience — autoswitch is
+  unusable without it, since configuring the battery profile would otherwise mean
+  applying it first. `resolveEditTargetLocked` + `commitEditLocked`
+  (`internal/daemon/profile.go`) are the single place that resolves and commits.
+- **Activating a custom profile *clears* the subsystems it does not set.**
+  `applyCustomHW` releases the fans when the profile has no curve, resets the
+  Curve Optimizer when it has no offset, and hands the PPT limits back to the
+  firmware profile underneath when it has no TDP. Without that, switching from a
+  profile with a 90W limit and a -25 offset to one that sets neither leaves both
+  in force while the daemon reports the second profile — and A→B→A does not give
+  the same machine as A. This only became reachable once custom→custom switching
+  existed. Ordering is the fail-closed part and is not free to rearrange: the
+  profile's own curve goes on *before* its TDP so `ApplyTDPSafely`'s floor is
+  written last and wins; clearing the TDP lowers power before the fans are
+  touched; and the fans are released only when no high sustained limit is in
+  force, so a high-TDP profile with no curve of its own keeps the floor
+  `ApplyTDPSafely` just wrote. `Run()` calls the same helper rather than
+  hand-rolling the restore, so startup cannot drift from it.
+- **There is exactly one apply-a-custom-profile sequence: `applyCustomHW`.** The
+  socket command, the autoswitch watcher, `Run()`'s startup restore and
+  `resume.go` all call it. Four hand-rolled copies is precisely how the ordering
+  and clearing rules drifted apart; `handleTDP`'s post-lower fan step is the last
+  place that repeats any of it, and it mirrors the same rule deliberately
+  (restore the profile's curve, else release the fans, so lowering a limit and
+  selecting the profile converge on the same hardware).
+- **A daemon restart does not reset the fan controller or the Curve Optimizer.**
+  Both are hardware state that outlives the process, so a custom profile that was
+  in force still is. If the startup autoswitch resolution moves off it onto a
+  firmware profile, `Run()` must release them exactly as `applyStockHW` would —
+  otherwise the machine keeps running the old curve and offset while reporting a
+  firmware profile, and the reconcile watcher stays inert because the profile is
+  no longer custom.
+- **Only a firmware profile name may reach `platform_profile`.** `Run()`'s
+  restore is gated on `cli.IsStockProfile`, not on "not custom": a state file
+  naming a profile that is neither — deleted by hand, or lost in a downgrade —
+  would otherwise be written straight to the attribute. `loadState` also clears
+  such a name, so `effectiveProfile` falls back to `platform_profile` instead of
+  every later lookup erroring.
+- **The profile CRUD handlers take `hwMu` even though they write no hardware.**
+  The edit handlers resolve a target under `d.mu`, release it for the hardware
+  write, then commit the profile back under `d.mu` again. Mutating the profile map
+  inside that window is silently undone by the commit — and for a delete, undone
+  by *resurrecting* the profile. `hwMu` is what makes the whole
+  resolve-write-commit span exclusive. It also keeps a delete from landing
+  part-way through `applyProfileLocked`, which would leave `state.Profile` naming
+  a profile that no longer exists and so stop the reconcile watcher defending a
+  fan curve that is live in hardware.
+  `internal/daemon/profile_test.go:TestProfileMutatorsTakeHwMu` is the guard.
+- **The `profile` request field is silently ignored by older daemons, which
+  makes an unguarded `--profile` edit apply to the running machine.** It is an
+  additive field, so a pre-1.3 daemon unmarshals the request, drops the field,
+  applies the setting live, and answers `ok` — the CLI would print "stored in
+  profile X (not applied)" over a real TDP change. This happened during
+  development. `cmd.ensureProfileTargetSupported` probes `profile-list` (which
+  answers `unknown command` on an older daemon) before every `--profile` send.
+  Any other client offering profile targeting must do the same.
+- **The firmware profile names are reserved at four layers.** `quiet`,
+  `balanced` and `performance` can never name a custom profile, so selecting one
+  always reaches the firmware profile: (1) `cli.ValidateProfileName` rejects
+  them, (2) `applyProfileLocked` tests `cli.IsStockProfile` *before* it consults
+  the map, (3) `api.State.IsCustomProfile` returns false for them ahead of the
+  lookup, and (4) `loadState` drops a `custom_profiles` entry carrying one. Layer
+  4 is not paranoia — `state.json` is a plain file a user can edit, and it parses
+  fine, so the other three never see it. The reservation is load-bearing beyond
+  aesthetics: `ReadEffectivePPT` disables its stale-5W fallback for any name
+  absent from `StockProfilePPT`, which is right for a custom profile and wrong
+  for a firmware one, so a custom "balanced" would misreport the power limits.
+  Name validation is strict on write (`profile-create`/`profile-save` reject
+  `Gaming` rather than folding it to `gaming`, or the user looks for a profile
+  under a name that is not there) and lenient on lookup (`--set` and `--profile`
+  do fold case).
+- **Switching to a firmware profile preserves every custom profile**; it resets
+  fan hardware to auto, clears the undervolt, and writes that profile's
+  `StockProfilePPT` row. `profile --set <custom>` errors if that profile has no
+  settings at all — there would be nothing to apply.
+- **AC/battery autoswitch is edge-triggered on `online`, never level-triggered,
+  and never reads `platform_profile`** (`internal/daemon/powersource.go`, issue
+  #6). That is the whole safety argument: the watcher reacts only to a value
+  neither z13ctl nor PPD nor the desktop can write, so the feedback loop that
+  would produce a write-fight does not exist. A level-triggered "keep my profile
+  applied" watcher would both fight PPD over every transition — the thing
+  `reconcile.go` exists to avoid — and make a manual profile change impossible to
+  hold. The intended semantics follow directly: a profile chosen by hand sticks
+  until the source actually changes, and z13ctl yields in between (GNOME's
+  Automatic Power Saver is a *low-battery* trigger, not an unplug trigger, and is
+  correctly ignored). One observation function, `cli.OnACPower()`, with two
+  triggers: a UPower `OnBattery` nudge for immediacy and a 2s poll as the
+  backstop for Gaming Mode / no-UPower setups — so there is one behaviour to
+  test, not two. An edge is confirmed on the following observation before
+  applying; that settle window lets PPD's own transition write land first (else
+  the custom curve is dropped until reconcile notices) and stops a loose USB-C
+  connector driving a full PPT+fan+SMU write per bounce. A failed apply latches
+  the source anyway and does not retry. **The startup apply lives in `Run()`, not
+  the watcher**, which latches its first observation without acting: `Run()`
+  holds the same-value guard that keeps a redundant `platform_profile` write —
+  and the WMI fan-controller reset that comes with it — out of every daemon
+  restart. There is deliberately no hook in `resume.go`: Go timers use
+  `CLOCK_MONOTONIC` and do not advance across suspend, so the armed timer fires
+  promptly after resume; duplicating it would race the watcher over `hwMu`.
+- **`cli.FindACOnlinePath` filters on `type == "Mains"`, never on the presence of
+  an `online` file.** On the Z13 the detachable keyboard registers as
+  `hid-*-battery-N` (type `Battery`) and the two USB-C ports as
+  `ucsi-source-psy-*` (type `USB`), and all of them expose `online` — a `*/online`
+  glob reports mains power whenever the cover is attached. `OnACPower` returns an
+  *error* when no Mains supply exists (VM, desktop, driver not yet bound); callers
+  must treat that as unknown and do nothing, never as "on battery".
 - **Stock PPT restore is explicit, not firmware-driven** (issue #12): the firmware
   does *not* re-apply per-profile PPT on a `platform_profile` write, and the
   `ppt_*` attributes have no "reset to firmware default" operation — writing 5W

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ z13ctl tdp --set 50
 
 # Undervolt CPU by -20 (Curve Optimizer, requires ryzen_smu)
 z13ctl undervolt --set -20
+
+# A different profile on AC and on battery.
+# --profile stores a setting without applying it, so you can build the battery
+# profile while still plugged in.
+z13ctl profile --create battery-uv
+z13ctl tdp --set 35 --profile battery-uv
+z13ctl undervolt --set -25 --profile battery-uv
+z13ctl autoswitch --ac balanced --battery battery-uv
 ```
 
 ## Documentation

--- a/api/client.go
+++ b/api/client.go
@@ -46,6 +46,13 @@ type request struct {
 	PL2        string   `json:"pl2,omitempty"`
 	PL3        string   `json:"pl3,omitempty"`
 	Force      bool     `json:"force,omitempty"`
+	// Profile names the custom profile a fancurve/tdp/undervolt command edits.
+	// Empty means the active profile, which is also what every client written
+	// before this field existed sends.
+	Profile string `json:"profile,omitempty"`
+	AC      string `json:"ac,omitempty"`
+	Battery string `json:"battery,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
 }
 
 // response is the reply to a command or a streamed event notification.
@@ -284,10 +291,17 @@ func SendFanCurveGet() (handled bool, value string, err error) {
 	return true, resp.Value, nil
 }
 
-// SendFanCurveSet sends a fan curve set command to the daemon.
-// The curve is applied to both fans simultaneously.
+// SendFanCurveSet sends a fan curve set command to the daemon, editing the
+// active custom profile. The curve is applied to both fans simultaneously.
 func SendFanCurveSet(curve string) (bool, error) {
-	handled, resp, err := sendCommand(request{Cmd: "fancurve", Set: curve})
+	return SendFanCurveSetFor("", curve)
+}
+
+// SendFanCurveSetFor stores a fan curve in the named custom profile. An empty
+// profile means the active one, in which case the curve is also written to
+// hardware; naming a profile that is not active only records it.
+func SendFanCurveSetFor(profile, curve string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "fancurve", Set: curve, Profile: profile})
 	if !handled || err != nil {
 		return handled, err
 	}
@@ -299,7 +313,14 @@ func SendFanCurveSet(curve string) (bool, error) {
 
 // SendFanCurveReset resets both fans to firmware auto mode.
 func SendFanCurveReset() (bool, error) {
-	handled, resp, err := sendCommand(request{Cmd: "fancurve-reset"})
+	return SendFanCurveResetFor("")
+}
+
+// SendFanCurveResetFor clears the fan curve from the named custom profile. An
+// empty profile means the active one, which also releases both fans to firmware
+// auto mode.
+func SendFanCurveResetFor(profile string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "fancurve-reset", Profile: profile})
 	if !handled || err != nil {
 		return handled, err
 	}
@@ -323,15 +344,24 @@ func SendTdpGet() (handled bool, value string, err error) {
 	return true, resp.Value, nil
 }
 
-// SendTdpSet sends a TDP set command to the daemon.
+// SendTdpSet sends a TDP set command to the daemon, editing the active custom
+// profile.
 func SendTdpSet(watts, pl1, pl2, pl3 string, force bool) (bool, error) {
+	return SendTdpSetFor("", watts, pl1, pl2, pl3, force)
+}
+
+// SendTdpSetFor stores TDP limits in the named custom profile. An empty profile
+// means the active one, in which case the limits are also written to hardware;
+// naming a profile that is not active only records them.
+func SendTdpSetFor(profile, watts, pl1, pl2, pl3 string, force bool) (bool, error) {
 	handled, resp, err := sendCommand(request{
-		Cmd:   "tdp",
-		Set:   watts,
-		PL1:   pl1,
-		PL2:   pl2,
-		PL3:   pl3,
-		Force: force,
+		Cmd:     "tdp",
+		Set:     watts,
+		PL1:     pl1,
+		PL2:     pl2,
+		PL3:     pl3,
+		Force:   force,
+		Profile: profile,
 	})
 	if !handled || err != nil {
 		return handled, err
@@ -344,7 +374,13 @@ func SendTdpSet(watts, pl1, pl2, pl3 string, force bool) (bool, error) {
 
 // SendTdpReset sends a TDP reset command to the daemon.
 func SendTdpReset() (bool, error) {
-	handled, resp, err := sendCommand(request{Cmd: "tdp-reset"})
+	return SendTdpResetFor("")
+}
+
+// SendTdpResetFor clears the TDP limits from the named custom profile. An empty
+// profile means the active one, which also restores stock power limits.
+func SendTdpResetFor(profile string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "tdp-reset", Profile: profile})
 	if !handled || err != nil {
 		return handled, err
 	}
@@ -368,10 +404,18 @@ func SendUndervoltGet() (handled bool, value string, err error) {
 	return true, resp.Value, nil
 }
 
-// SendUndervoltSet sends a Curve Optimizer set command to the daemon.
-// cpu is a string representation of the CO offset (e.g. "-20").
+// SendUndervoltSet sends a Curve Optimizer set command to the daemon, editing
+// the active custom profile. cpu is a string representation of the CO offset
+// (e.g. "-20").
 func SendUndervoltSet(cpu string) (bool, error) {
-	handled, resp, err := sendCommand(request{Cmd: "undervolt", Set: cpu})
+	return SendUndervoltSetFor("", cpu)
+}
+
+// SendUndervoltSetFor stores a Curve Optimizer offset in the named custom
+// profile. An empty profile means the active one, in which case the offset is
+// also applied to hardware; naming a profile that is not active only records it.
+func SendUndervoltSetFor(profile, cpu string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "undervolt", Set: cpu, Profile: profile})
 	if !handled || err != nil {
 		return handled, err
 	}
@@ -383,7 +427,13 @@ func SendUndervoltSet(cpu string) (bool, error) {
 
 // SendUndervoltReset resets Curve Optimizer to stock (0).
 func SendUndervoltReset() (bool, error) {
-	handled, resp, err := sendCommand(request{Cmd: "undervolt-reset"})
+	return SendUndervoltResetFor("")
+}
+
+// SendUndervoltResetFor clears the Curve Optimizer offset from the named custom
+// profile. An empty profile means the active one, which also resets hardware.
+func SendUndervoltResetFor(profile string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "undervolt-reset", Profile: profile})
 	if !handled || err != nil {
 		return handled, err
 	}
@@ -391,6 +441,92 @@ func SendUndervoltReset() (bool, error) {
 		return true, fmt.Errorf("%s", resp.Error)
 	}
 	return true, nil
+}
+
+// SendProfileCreate creates an empty custom profile. It does not activate it.
+func SendProfileCreate(name string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "profile-create", Set: name})
+	if !handled || err != nil {
+		return handled, err
+	}
+	if !resp.OK {
+		return true, fmt.Errorf("%s", resp.Error)
+	}
+	return true, nil
+}
+
+// SendProfileSave copies the active custom profile under a new name. It does
+// not activate the copy.
+func SendProfileSave(name string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "profile-save", Set: name})
+	if !handled || err != nil {
+		return handled, err
+	}
+	if !resp.OK {
+		return true, fmt.Errorf("%s", resp.Error)
+	}
+	return true, nil
+}
+
+// SendProfileDelete removes a saved custom profile. The daemon refuses to
+// delete the active profile or one referenced by autoswitch.
+func SendProfileDelete(name string) (bool, error) {
+	handled, resp, err := sendCommand(request{Cmd: "profile-delete", Set: name})
+	if !handled || err != nil {
+		return handled, err
+	}
+	if !resp.OK {
+		return true, fmt.Errorf("%s", resp.Error)
+	}
+	return true, nil
+}
+
+// SendProfileList queries the daemon for the saved custom profiles.
+// Returns a JSON array of CustomProfile. Returns (false, "", nil) if the daemon
+// is not running.
+func SendProfileList() (handled bool, value string, err error) {
+	var resp *response
+	handled, resp, err = sendCommand(request{Cmd: "profile-list"})
+	if !handled || err != nil {
+		return handled, "", err
+	}
+	if !resp.OK {
+		return true, "", fmt.Errorf("%s", resp.Error)
+	}
+	return true, resp.Value, nil
+}
+
+// SendAutoswitchSet configures automatic profile selection by power source.
+// An empty ac or battery target leaves the profile alone on that source.
+func SendAutoswitchSet(enabled bool, ac, battery string) (bool, error) {
+	handled, resp, err := sendCommand(request{
+		Cmd:     "autoswitch",
+		Enabled: enabled,
+		AC:      ac,
+		Battery: battery,
+	})
+	if !handled || err != nil {
+		return handled, err
+	}
+	if !resp.OK {
+		return true, fmt.Errorf("%s", resp.Error)
+	}
+	return true, nil
+}
+
+// SendAutoswitchGet queries the daemon for the autoswitch configuration.
+// Returns a JSON AutoswitchState. Returns (false, "", nil) if the daemon is not
+// running.
+func SendAutoswitchGet() (handled bool, value string, err error) {
+	var resp *response
+	handled, resp, err = sendCommand(request{Cmd: "autoswitch-get"})
+	if !handled || err != nil {
+		return handled, "", err
+	}
+	if !resp.OK {
+		return true, "", fmt.Errorf("%s", resp.Error)
+	}
+	return true, resp.Value, nil
 }
 
 // SendGetState fetches the daemon's full cached state for GUI initialization.

--- a/api/client.go
+++ b/api/client.go
@@ -8,7 +8,8 @@ package api
 // back to direct hardware access.
 //
 // Subscribe opens a long-lived connection and returns a channel that receives
-// event name strings streamed by the daemon.
+// event name strings streamed by the daemon. Event names and their meanings are
+// in events.go.
 
 import (
 	"bufio"
@@ -543,7 +544,24 @@ func SendGetState() (bool, *State, error) {
 }
 
 // Subscribe opens a long-lived subscription to the daemon and returns a channel
-// that receives event name strings (e.g. "gui-toggle") as they are streamed.
+// that receives event name strings as they are streamed. Pass the events you
+// want — EventGUIToggle, EventPowerSource, EventStateChanged — or nil for all of
+// them. The daemon honours the list, so a client that asks only for
+// EventGUIToggle will not be woken by anything else.
+//
+// Events carry no payload by design: the name says what happened, and
+// SendGetState answers with current truth. Switch on the name rather than
+// treating every event alike —
+//
+//	for ev := range ch {
+//	    switch ev {
+//	    case api.EventGUIToggle:
+//	        toggleWindow()
+//	    case api.EventPowerSource, api.EventStateChanged:
+//	        refreshFromGetState()
+//	    }
+//	}
+//
 // The returned cancel func closes the underlying connection and stops the
 // goroutine; the channel is closed when the connection drops or cancel is called.
 // Returns (nil, nil, nil) if the daemon is not running.

--- a/api/events.go
+++ b/api/events.go
@@ -1,0 +1,34 @@
+package api
+
+// events.go — the event names a client can subscribe to.
+//
+// Events are deliberately bare notifications: the name says what happened, and
+// the client calls SendGetState for the details. Carrying a state payload on the
+// event would save a round trip on a local socket — worth nothing — and would
+// introduce a staleness race, because a payload describes the moment the event
+// was queued while get-state always answers with current truth.
+
+const (
+	// EventGUIToggle is emitted when the Armoury Crate button is pressed.
+	EventGUIToggle = "gui-toggle"
+
+	// EventPowerSource is emitted when the machine moves between mains and
+	// battery power. It fires on the transition itself, so it is useful whether
+	// or not autoswitch is configured — a client can drive a plug/battery
+	// indicator from it alone.
+	EventPowerSource = "power-source"
+
+	// EventStateChanged is emitted when the active profile, its settings, the
+	// saved profiles, or the autoswitch configuration change — whatever the
+	// cause: this client, another client, the CLI, autoswitch, or a resume.
+	// A client displaying profile, TDP, fan curve, or undervolt values should
+	// re-read them with SendGetState when it arrives.
+	//
+	// Lighting is deliberately excluded. A brightness slider drag would emit a
+	// burst of events describing values the client just set itself.
+	EventStateChanged = "state-changed"
+)
+
+// AllEvents lists every event name the daemon can emit. Subscribing with an
+// empty event list is equivalent to subscribing to all of them.
+var AllEvents = []string{EventGUIToggle, EventPowerSource, EventStateChanged}

--- a/api/example_test.go
+++ b/api/example_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/dahui/z13ctl/api"
@@ -315,4 +316,192 @@ func ExampleSubscribe() {
 	for event := range ch {
 		fmt.Println("received event:", event)
 	}
+}
+
+func ExampleSendProfileCreate() {
+	// Create an empty custom profile. It is not activated; add settings with
+	// the *For variants, then select it with SendProfileSet.
+	handled, err := api.SendProfileCreate("battery-uv")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("profile created")
+}
+
+func ExampleSendProfileSave() {
+	// Copy the profile currently in force under a new name, leaving the
+	// original active.
+	handled, err := api.SendProfileSave("gaming")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("profile copied")
+}
+
+func ExampleSendProfileDelete() {
+	// The daemon refuses to delete the active profile or one referenced by
+	// autoswitch.
+	handled, err := api.SendProfileDelete("gaming")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("profile deleted")
+}
+
+func ExampleSendProfileList() {
+	handled, value, err := api.SendProfileList()
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	var profiles []struct {
+		api.CustomProfile
+		Active bool `json:"active"`
+	}
+	if err := json.Unmarshal([]byte(value), &profiles); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	for _, p := range profiles {
+		fmt.Println(p.Name, p.Active)
+	}
+}
+
+func ExampleSendTdpSetFor() {
+	// Store a 35W limit in a profile that is not running. Nothing is applied to
+	// hardware, which is what makes it possible to build the profile autoswitch
+	// selects on battery while still plugged in.
+	handled, err := api.SendTdpSetFor("battery-uv", "35", "", "", "", false)
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("stored in battery-uv")
+}
+
+func ExampleSendFanCurveSetFor() {
+	// An empty profile name edits the active profile and writes hardware, which
+	// is exactly what SendFanCurveSet does.
+	handled, err := api.SendFanCurveSetFor("battery-uv", "30:40%,40:45%,50:50%,60:60%,70:70%,80:85%,90:100%,100:100%")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("stored in battery-uv")
+}
+
+func ExampleSendFanCurveResetFor() {
+	// Clear the fan curve from a stored profile, so it no longer controls fans.
+	handled, err := api.SendFanCurveResetFor("battery-uv")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("fan curve cleared")
+}
+
+func ExampleSendTdpResetFor() {
+	handled, err := api.SendTdpResetFor("battery-uv")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("power limits cleared")
+}
+
+func ExampleSendUndervoltSetFor() {
+	handled, err := api.SendUndervoltSetFor("battery-uv", "-25")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("stored in battery-uv")
+}
+
+func ExampleSendUndervoltResetFor() {
+	handled, err := api.SendUndervoltResetFor("battery-uv")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("undervolt cleared")
+}
+
+func ExampleSendAutoswitchSet() {
+	// Balanced on AC, a custom profile on battery. An empty target leaves that
+	// side to the desktop's own power management.
+	handled, err := api.SendAutoswitchSet(true, "balanced", "battery-uv")
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("autoswitch configured")
+}
+
+func ExampleSendAutoswitchGet() {
+	handled, value, err := api.SendAutoswitchGet()
+	if !handled {
+		fmt.Println("daemon not running")
+		return
+	}
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	var st struct {
+		api.AutoswitchState
+		OnAC bool `json:"on_ac"`
+	}
+	if err := json.Unmarshal([]byte(value), &st); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(st.Enabled, st.AC, st.Battery, st.OnAC)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -6,6 +6,14 @@ package api
 
 // State holds the last-applied settings for all controllable subsystems.
 // It is returned by SendGetState and broadcast as part of daemon responses.
+//
+// CustomProfiles is the source of truth for custom settings. FanCurve, TDP and
+// Undervolt are a projection, retained so clients written against earlier
+// versions keep working: they carry the active custom profile's settings, or
+// the default "custom" profile's when a firmware profile is active — the same
+// values selecting "custom" would recall. Undervolt.Active is what says whether
+// an offset is applied to hardware right now; the values themselves survive a
+// switch to a firmware profile so they can be recalled.
 type State struct {
 	Lighting           LightingState            `json:"lighting"`
 	Devices            map[string]LightingState `json:"devices,omitempty"` // per-device overrides keyed by name
@@ -13,12 +21,110 @@ type State struct {
 	Battery            int                      `json:"battery_limit,omitempty"`
 	BootSound          int                      `json:"boot_sound,omitempty"`
 	PanelOverdrive     int                      `json:"panel_overdrive,omitempty"`
-	FanCurve           *FanCurveState           `json:"fan_curve,omitempty"`
-	TDP                *TDPState                `json:"tdp,omitempty"`
-	Undervolt          *UndervoltState          `json:"undervolt,omitempty"`
+	CustomProfiles     map[string]CustomProfile `json:"custom_profiles,omitempty"` // saved custom profiles keyed by name
+	Autoswitch         *AutoswitchState         `json:"autoswitch,omitempty"`
+	FanCurve           *FanCurveState           `json:"fan_curve,omitempty"`   // projection; see the type doc
+	TDP                *TDPState                `json:"tdp,omitempty"`         // projection; see the type doc
+	Undervolt          *UndervoltState          `json:"undervolt,omitempty"`   // projection; see the type doc
 	UndervoltAvailable bool                     `json:"undervolt_available"`   // true if ryzen_smu is loaded
+	OnAC               bool                     `json:"on_ac"`                 // true when running on mains power
 	Temperature        int                      `json:"temperature,omitempty"` // APU temp, degrees Celsius
 	FanRPM             int                      `json:"fan_rpm,omitempty"`     // fan1 speed in RPM
+}
+
+// StockProfiles are the firmware performance profiles that can be written to
+// platform_profile. They are reserved: a custom profile can never take one of
+// these names, so selecting one always reaches the firmware profile.
+var StockProfiles = []string{"quiet", "balanced", "performance"}
+
+// DefaultCustomProfile is the name of the custom profile created implicitly by
+// the first fan curve, TDP, or undervolt setting made while a stock profile is
+// active. It is reserved and cannot be chosen as a user-supplied name.
+const DefaultCustomProfile = "custom"
+
+// IsStockProfileName reports whether name is one of the reserved firmware
+// profile names.
+func IsStockProfileName(name string) bool {
+	for _, p := range StockProfiles {
+		if name == p {
+			return true
+		}
+	}
+	return false
+}
+
+// CustomProfile is a named set of custom hardware settings. Each subsystem is a
+// pointer so that nil means "this profile does not control that subsystem",
+// which is what lets a profile stay loadable as new subsystems are added.
+type CustomProfile struct {
+	Name      string          `json:"name"`
+	FanCurve  *FanCurveState  `json:"fan_curve,omitempty"`
+	TDP       *TDPState       `json:"tdp,omitempty"`
+	Undervolt *UndervoltState `json:"undervolt,omitempty"`
+}
+
+// Empty reports whether the profile controls no subsystem at all. An empty
+// profile cannot be activated: there would be nothing to apply.
+func (p CustomProfile) Empty() bool {
+	return p.FanCurve == nil && p.TDP == nil && p.Undervolt == nil
+}
+
+// AutoswitchState configures automatic profile selection by power source.
+// An empty AC or Battery target means "leave the profile alone on that source",
+// which is how a caller hands one side back to power-profiles-daemon.
+type AutoswitchState struct {
+	Enabled bool   `json:"enabled"`
+	AC      string `json:"ac,omitempty"`
+	Battery string `json:"battery,omitempty"`
+}
+
+// Target returns the profile to apply for the given power source, or "" when
+// autoswitch is disabled or that side is unconfigured.
+func (a *AutoswitchState) Target(onAC bool) string {
+	if a == nil || !a.Enabled {
+		return ""
+	}
+	if onAC {
+		return a.AC
+	}
+	return a.Battery
+}
+
+// IsCustomProfile reports whether name identifies a z13ctl-managed custom
+// profile: the default "custom" profile, or a saved named one.
+//
+// Clients that check Profile == "custom" to decide whether custom controls
+// apply must move to this — a named profile would otherwise read as stock.
+//
+// A reserved firmware profile name is never custom, whatever the map contains.
+// The check is deliberately ahead of the lookup so that a hand-edited state file
+// cannot make a stock profile look custom to the fan curve reconciler.
+func (s State) IsCustomProfile(name string) bool {
+	if name == "" || IsStockProfileName(name) {
+		return false
+	}
+	if name == DefaultCustomProfile {
+		return true
+	}
+	_, ok := s.CustomProfiles[name]
+	return ok
+}
+
+// InCustomProfile reports whether the active profile is a custom one.
+func (s State) InCustomProfile() bool { return s.IsCustomProfile(s.Profile) }
+
+// ActiveCustomProfile returns the active custom profile and true, or the zero
+// value and false when a stock profile is active.
+func (s State) ActiveCustomProfile() (CustomProfile, bool) {
+	if !s.InCustomProfile() {
+		return CustomProfile{}, false
+	}
+	p, ok := s.CustomProfiles[s.Profile]
+	if !ok {
+		// "custom" is addressable before it has ever been populated.
+		return CustomProfile{Name: s.Profile}, true
+	}
+	return p, true
 }
 
 // LightingState captures all parameters needed to reproduce one lighting zone.

--- a/cmd/autoswitch.go
+++ b/cmd/autoswitch.go
@@ -1,0 +1,191 @@
+package cmd
+
+// autoswitch.go — "autoswitch" subcommand: pick a profile automatically by
+// power source. Configuration only; the daemon does the switching.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	autoswitchGetFlag     bool
+	autoswitchACFlag      string
+	autoswitchBatteryFlag string
+	autoswitchOnFlag      bool
+	autoswitchOffFlag     bool
+	autoswitchClearFlag   bool
+)
+
+var autoswitchCmd = &cobra.Command{
+	Use:   "autoswitch",
+	Short: "Apply a different profile on AC and on battery",
+	Long: `Apply a different profile automatically when the charger is plugged or unplugged.
+
+Each side takes any profile name: a firmware profile (quiet, balanced,
+performance) or a custom profile. Setting --ac or --battery enables autoswitch
+unless --off is given.
+
+An empty target leaves that side alone, which hands it back to your desktop's
+power management:
+
+  z13ctl autoswitch --ac "" --battery battery-uv
+
+Build the profile you want on battery before selecting it here — '--profile' on
+'tdp', 'fancurve' and 'undervolt' edits a profile without applying it:
+
+  z13ctl profile --create battery-uv
+  z13ctl tdp --set 35 --profile battery-uv
+  z13ctl undervolt --set -25 --profile battery-uv
+  z13ctl autoswitch --ac balanced --battery battery-uv
+
+Autoswitch acts only when the power source actually changes. A profile you pick
+by hand therefore stays until the next plug or unplug, and z13ctl does not
+contest the profile with power-profiles-daemon in between. One consequence
+worth knowing: GNOME's "Automatic Power Saver" triggers on low battery rather
+than on unplugging, so it can still move a firmware profile afterwards.
+
+Requires the daemon, which is what watches the power source.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if autoswitchGetFlag {
+			return runAutoswitchGet()
+		}
+		if !cmd.Flags().Changed("ac") && !cmd.Flags().Changed("battery") &&
+			!autoswitchOnFlag && !autoswitchOffFlag && !autoswitchClearFlag {
+			return cmd.Help()
+		}
+		return runAutoswitchSet(cmd)
+	},
+}
+
+func runAutoswitchSet(cmd *cobra.Command) error {
+	if autoswitchOnFlag && autoswitchOffFlag {
+		return fmt.Errorf("--on and --off are mutually exclusive")
+	}
+	if autoswitchClearFlag && (autoswitchACFlag != "" || autoswitchBatteryFlag != "" || autoswitchOnFlag) {
+		return fmt.Errorf("--clear cannot be combined with --ac, --battery, or --on")
+	}
+
+	ac := strings.ToLower(strings.TrimSpace(autoswitchACFlag))
+	battery := strings.ToLower(strings.TrimSpace(autoswitchBatteryFlag))
+	enabled := !autoswitchOffFlag && !autoswitchClearFlag
+
+	if autoswitchClearFlag {
+		ac, battery = "", ""
+	} else {
+		// Every side the user did not name keeps its configured value. Without
+		// this, 'autoswitch --ac quiet' would silently wipe the battery target —
+		// the command reads as "change the AC side", not "replace both".
+		// An explicit --ac "" still clears that side, because the flag was given.
+		acGiven, batGiven := cmd.Flags().Changed("ac"), cmd.Flags().Changed("battery")
+		if !acGiven || !batGiven {
+			cur, err := currentAutoswitch()
+			if err != nil {
+				return err
+			}
+			if !acGiven {
+				ac = cur.AC
+			}
+			if !batGiven {
+				battery = cur.Battery
+			}
+			if enabled && ac == "" && battery == "" {
+				return fmt.Errorf("nothing to enable: set a target first, e.g. 'z13ctl autoswitch --ac balanced --battery custom'")
+			}
+		}
+	}
+
+	if dryRunFlag {
+		cli.DryRunAutoswitch(enabled, ac, battery)
+		return nil
+	}
+
+	handled, err := api.SendAutoswitchSet(enabled, ac, battery)
+	if !handled {
+		return fmt.Errorf("autoswitch requires the daemon, which watches the power source; start it first")
+	}
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		fmt.Println("Autoswitch disabled")
+		return nil
+	}
+	fmt.Printf("Autoswitch enabled: %s on AC, %s on battery\n", describeTarget(ac), describeTarget(battery))
+	return nil
+}
+
+// autoswitchStatus mirrors the daemon's autoswitch-get payload.
+type autoswitchStatus struct {
+	api.AutoswitchState
+	OnAC        bool `json:"on_ac"`
+	SourceKnown bool `json:"source_known"`
+}
+
+func currentAutoswitch() (autoswitchStatus, error) {
+	var st autoswitchStatus
+	handled, value, err := api.SendAutoswitchGet()
+	if !handled {
+		return st, fmt.Errorf("autoswitch requires the daemon, which watches the power source; start it first")
+	}
+	if err != nil {
+		return st, err
+	}
+	if err := json.Unmarshal([]byte(value), &st); err != nil {
+		return st, fmt.Errorf("parsing autoswitch state: %w", err)
+	}
+	return st, nil
+}
+
+func runAutoswitchGet() error {
+	st, err := currentAutoswitch()
+	if err != nil {
+		return err
+	}
+
+	state := "disabled"
+	if st.Enabled {
+		state = "enabled"
+	}
+	fmt.Printf("Autoswitch: %s\n", state)
+	fmt.Printf("  AC:      %s\n", describeTarget(st.AC))
+	fmt.Printf("  Battery: %s\n", describeTarget(st.Battery))
+	if !st.SourceKnown {
+		fmt.Println("  Source:  unknown (no mains power supply found)")
+		return nil
+	}
+	source, target := "battery", st.Battery
+	if st.OnAC {
+		source, target = "AC", st.AC
+	}
+	if st.Enabled && target != "" {
+		fmt.Printf("  Source:  %s (would select %s)\n", source, target)
+	} else {
+		fmt.Printf("  Source:  %s\n", source)
+	}
+	return nil
+}
+
+func describeTarget(name string) string {
+	if name == "" {
+		return "(unchanged)"
+	}
+	return name
+}
+
+func init() {
+	autoswitchCmd.Flags().BoolVar(&autoswitchGetFlag, "get", false, "Print the autoswitch configuration and current power source")
+	autoswitchCmd.Flags().StringVar(&autoswitchACFlag, "ac", "", "Profile to apply on AC power (empty leaves the profile alone)")
+	autoswitchCmd.Flags().StringVar(&autoswitchBatteryFlag, "battery", "", "Profile to apply on battery (empty leaves the profile alone)")
+	autoswitchCmd.Flags().BoolVar(&autoswitchOnFlag, "on", false, "Enable autoswitch with the configured targets")
+	autoswitchCmd.Flags().BoolVar(&autoswitchOffFlag, "off", false, "Disable autoswitch, keeping the configured targets")
+	autoswitchCmd.Flags().BoolVar(&autoswitchClearFlag, "clear", false, "Disable autoswitch and clear both targets")
+	rootCmd.AddCommand(autoswitchCmd)
+}

--- a/cmd/autoswitch_test.go
+++ b/cmd/autoswitch_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+// autoswitch_test.go — flag-combination rejections for the autoswitch command,
+// and profile-name parity with the daemon.
+//
+// Only cases that return before any socket or sysfs access belong here: the
+// accepted paths call api.Send*, which reaches a running daemon and would
+// reconfigure the developer's machine.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+// resetAutoswitchFlags restores the package-level flag vars between cases.
+// Cobra flags are process-global, so a case that leaves one set changes the
+// meaning of the next.
+func resetAutoswitchFlags(t *testing.T) {
+	t.Helper()
+	prev := struct {
+		get, on, off, clear bool
+		ac, battery         string
+	}{autoswitchGetFlag, autoswitchOnFlag, autoswitchOffFlag, autoswitchClearFlag, autoswitchACFlag, autoswitchBatteryFlag}
+	t.Cleanup(func() {
+		autoswitchGetFlag, autoswitchOnFlag = prev.get, prev.on
+		autoswitchOffFlag, autoswitchClearFlag = prev.off, prev.clear
+		autoswitchACFlag, autoswitchBatteryFlag = prev.ac, prev.battery
+	})
+	autoswitchGetFlag, autoswitchOnFlag, autoswitchOffFlag, autoswitchClearFlag = false, false, false, false
+	autoswitchACFlag, autoswitchBatteryFlag = "", ""
+}
+
+// fakeAutoswitchCmd is a command carrying the same flag set, so
+// cmd.Flags().Changed() answers correctly without touching the real rootCmd.
+func fakeAutoswitchCmd(args ...string) (*cobra.Command, error) {
+	c := &cobra.Command{Use: "autoswitch", RunE: func(*cobra.Command, []string) error { return nil }}
+	c.Flags().BoolVar(&autoswitchGetFlag, "get", false, "")
+	c.Flags().StringVar(&autoswitchACFlag, "ac", "", "")
+	c.Flags().StringVar(&autoswitchBatteryFlag, "battery", "", "")
+	c.Flags().BoolVar(&autoswitchOnFlag, "on", false, "")
+	c.Flags().BoolVar(&autoswitchOffFlag, "off", false, "")
+	c.Flags().BoolVar(&autoswitchClearFlag, "clear", false, "")
+	err := c.ParseFlags(args)
+	return c, err
+}
+
+func TestAutoswitchRejectsConflictingFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"on with off", []string{"--on", "--off"}, "mutually exclusive"},
+		{"clear with ac", []string{"--clear", "--ac", "balanced"}, "cannot be combined"},
+		{"clear with battery", []string{"--clear", "--battery", "custom"}, "cannot be combined"},
+		{"clear with on", []string{"--clear", "--on"}, "cannot be combined"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAutoswitchFlags(t)
+			c, err := fakeAutoswitchCmd(tt.args...)
+			if err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			err = runAutoswitchSet(c)
+			if err == nil {
+				t.Fatalf("runAutoswitchSet(%v) = nil, want a rejection", tt.args)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestProfileNameValidationParity keeps the CLI's front-door check in step with
+// the daemon's: both go through cli.ValidateProfileName, so a name the daemon
+// would refuse must not get as far as the socket.
+func TestProfileNameValidationParity(t *testing.T) {
+	for _, name := range []string{"", "quiet", "balanced", "performance", "custom", "Gaming", "has space", "a/b"} {
+		if err := cli.ValidateProfileName(name); err == nil {
+			t.Errorf("ValidateProfileName(%q) = nil, want a rejection", name)
+		}
+	}
+	for _, name := range []string{"gaming", "battery-uv", "my_profile2"} {
+		if err := cli.ValidateProfileName(name); err != nil {
+			t.Errorf("ValidateProfileName(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+// TestRequireDaemonForProfile covers the guard that keeps "--profile X" from
+// falling through to the direct path, where it would apply the setting to the
+// running machine — the opposite of what --profile asks for.
+func TestRequireDaemonForProfile(t *testing.T) {
+	if err := requireDaemonForProfile(""); err != nil {
+		t.Errorf("requireDaemonForProfile(\"\") = %v, want nil so the normal direct path still works", err)
+	}
+	err := requireDaemonForProfile("battery-uv")
+	if err == nil {
+		t.Fatal("requireDaemonForProfile(\"battery-uv\") = nil, want an error explaining the daemon is required")
+	}
+	if !strings.Contains(err.Error(), "battery-uv") {
+		t.Errorf("error = %q, want it to name the profile", err)
+	}
+}
+
+func TestProfileEditMessage(t *testing.T) {
+	if got := profileEditMessage("", "TDP set to 35W"); got != "TDP set to 35W\n" {
+		t.Errorf("profileEditMessage with no profile = %q, want the applied message unchanged", got)
+	}
+	got := profileEditMessage("battery-uv", "TDP set to 35W")
+	if strings.Contains(got, "TDP set to 35W") {
+		t.Errorf("a --profile edit reported as applied: %q", got)
+	}
+	if !strings.Contains(got, "battery-uv") || !strings.Contains(got, "not applied") {
+		t.Errorf("message = %q, want it to name the profile and say it was not applied", got)
+	}
+}
+
+// TestAutoswitchPreservesTheUnnamedSide documents the rule the flag handling
+// implements: naming one side changes only that side. Without it,
+// "autoswitch --ac quiet" silently wiped the battery target, because the unset
+// flag read as an explicit empty value.
+//
+// It asserts on the flag-resolution rule rather than driving runAutoswitchSet,
+// which needs a live daemon to read the current configuration back.
+func TestAutoswitchPreservesTheUnnamedSide(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		wantACGiven      bool
+		wantBatteryGiven bool
+	}{
+		{"only --ac", []string{"--ac", "quiet"}, true, false},
+		{"only --battery", []string{"--battery", "custom"}, false, true},
+		{"both", []string{"--ac", "quiet", "--battery", "custom"}, true, true},
+		{"neither", []string{"--on"}, false, false},
+		// An explicit empty value is a deliberate clear, not an omission.
+		{"explicit empty ac", []string{"--ac", ""}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAutoswitchFlags(t)
+			c, err := fakeAutoswitchCmd(tt.args...)
+			if err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			if got := c.Flags().Changed("ac"); got != tt.wantACGiven {
+				t.Errorf("ac given = %v, want %v", got, tt.wantACGiven)
+			}
+			if got := c.Flags().Changed("battery"); got != tt.wantBatteryGiven {
+				t.Errorf("battery given = %v, want %v", got, tt.wantBatteryGiven)
+			}
+		})
+	}
+}

--- a/cmd/fancurve.go
+++ b/cmd/fancurve.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	fanCurveGetFlag   bool
-	fanCurveSetFlag   string
-	fanCurveResetFlag bool
+	fanCurveGetFlag     bool
+	fanCurveSetFlag     string
+	fanCurveResetFlag   bool
+	fanCurveProfileFlag string
 )
 
 var fancurveCmd = &cobra.Command{
@@ -46,9 +47,14 @@ power modes, power-profiles-daemon (including its automatic AC/battery
 switching), Fn+F5, asusctl. Run the daemon and it re-applies your curve within
 a couple of seconds; without it, re-run --set after any profile change.
 
+Use --profile <name> to store a curve in a profile you are NOT running: nothing
+is written to the fans, which is how you build the profile 'z13ctl autoswitch'
+selects on battery.
+
 Safety: while sustained TDP (PL1) is above 75W, every curve point must be at
 least 127 PWM (50%) and --reset is refused, since firmware auto mode has no
-minimum. Lower the limit first with 'z13ctl tdp --reset'.`,
+minimum. Lower the limit first with 'z13ctl tdp --reset'. A curve stored in a
+profile you are not running is checked against that profile's own power limit.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !fanCurveGetFlag && fanCurveSetFlag == "" && !fanCurveResetFlag {
@@ -104,18 +110,34 @@ func runFanCurveSet() error {
 	}
 
 	// Enforce the minimum PWM floor when sustained TDP exceeds the safe max.
-	if err := cli.CheckFanCurveFloor(effectiveProfileForTDP(), points); err != nil {
-		return err
+	// Only meaningful for the running machine: when --profile names another
+	// profile the daemon checks the curve against that profile's own TDP, since
+	// hardware says nothing about a profile that is not applied.
+	if fanCurveProfileFlag == "" {
+		if err := cli.CheckFanCurveFloor(effectiveProfileForTDP(), points); err != nil {
+			return err
+		}
 	}
 
 	if dryRunFlag {
+		if fanCurveProfileFlag != "" {
+			cli.DryRunProfileEdit(fanCurveProfileFlag, "fan curve")
+			return nil
+		}
 		cli.DryRunFanCurve(points)
 		return nil
 	}
 
-	if handled, err := api.SendFanCurveSet(fanCurveSetFlag); handled {
+	if err := ensureProfileTargetSupported(fanCurveProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendFanCurveSetFor(fanCurveProfileFlag, fanCurveSetFlag); handled {
 		if err != nil {
 			return err
+		}
+		if fanCurveProfileFlag != "" {
+			fmt.Print(profileEditMessage(fanCurveProfileFlag, ""))
+			return nil
 		}
 		fmt.Println("Fan curves set for both fans (custom mode enabled)")
 		fmt.Println("  Note: the kernel driver drops custom fan curves whenever the system power")
@@ -124,6 +146,9 @@ func runFanCurveSet() error {
 		return nil
 	}
 
+	if err := requireDaemonForProfile(fanCurveProfileFlag); err != nil {
+		return err
+	}
 	if err := cli.SetBothFanCurves(points); err != nil {
 		return fmt.Errorf("setting fan curves: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
 	}
@@ -143,21 +168,37 @@ func runFanCurveReset() error {
 	// Firmware auto has no PWM floor, so releasing the fans while a high
 	// sustained TDP is still in force removes the protection the high-TDP curve
 	// provides. "tdp --reset" is the way out — it lowers power first.
-	if err := cli.CheckFanFloorRelease(effectiveProfileForTDP()); err != nil {
-		return err
+	if fanCurveProfileFlag == "" {
+		if err := cli.CheckFanFloorRelease(effectiveProfileForTDP()); err != nil {
+			return err
+		}
 	}
 
 	if dryRunFlag {
+		if fanCurveProfileFlag != "" {
+			cli.DryRunProfileEdit(fanCurveProfileFlag, "cleared fan curve")
+			return nil
+		}
 		cli.DryRunFanCurveReset()
 		return nil
 	}
 
-	if handled, err := api.SendFanCurveReset(); handled {
+	if err := ensureProfileTargetSupported(fanCurveProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendFanCurveResetFor(fanCurveProfileFlag); handled {
 		if err != nil {
 			return err
 		}
+		if fanCurveProfileFlag != "" {
+			fmt.Printf("Cleared the fan curve from profile %s\n", fanCurveProfileFlag)
+			return nil
+		}
 		fmt.Println("Fan curves reset to auto mode (both fans)")
 		return nil
+	}
+	if err := requireDaemonForProfile(fanCurveProfileFlag); err != nil {
+		return err
 	}
 	if err := cli.ResetAllFanCurves(); err != nil {
 		return fmt.Errorf("resetting fan curves: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
@@ -170,5 +211,6 @@ func init() {
 	fancurveCmd.Flags().BoolVar(&fanCurveGetFlag, "get", false, "Print the current fan curve, mode, and RPM")
 	fancurveCmd.Flags().StringVar(&fanCurveSetFlag, "set", "", "Set a custom 8-point fan curve (temp:pwm or temp:pct%,...)")
 	fancurveCmd.Flags().BoolVar(&fanCurveResetFlag, "reset", false, "Restore firmware auto fan mode")
+	fancurveCmd.Flags().StringVar(&fanCurveProfileFlag, "profile", "", profileFlagUsage)
 	rootCmd.AddCommand(fancurveCmd)
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,9 +1,16 @@
 package cmd
 
-// profile.go — "profile" subcommand: read or set the performance profile via
-// the asus-wmi platform_profile sysfs interface. No HID access required.
+// profile.go — "profile" subcommand: read or set the performance profile, and
+// manage named custom profiles.
+//
+// The three firmware profiles are written to platform_profile via asus-wmi. A
+// custom profile is z13ctl's own: a named set of fan curve, TDP and undervolt
+// settings that it applies itself and never writes to platform_profile. The
+// firmware names are reserved, so selecting one always reaches the firmware
+// profile and can never be shadowed by a custom profile.
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -15,83 +22,238 @@ import (
 )
 
 var (
-	profileGetFlag bool
-	profileSetFlag string
+	profileGetFlag    bool
+	profileSetFlag    string
+	profileListFlag   bool
+	profileCreateFlag string
+	profileSaveAsFlag string
+	profileDeleteFlag string
 )
 
 var profileCmd = &cobra.Command{
 	Use:   "profile",
-	Short: "Get or set the performance profile via asus-wmi",
-	Long: `Get or set the performance profile via the Linux asus-wmi sysfs interface.
+	Short: "Get or set the performance profile, or manage custom profiles",
+	Long: `Get or set the performance profile, or manage named custom profiles.
 
-Profiles:
+Firmware profiles (written to platform_profile via asus-wmi):
   quiet        — Silent/Eco mode (low power, low noise)
   balanced     — Balanced mode   (default)
   performance  — Turbo mode      (maximum performance)
-  custom       — Re-apply saved custom fan curves and TDP from state`,
+
+Custom profiles are z13ctl's own: a named set of fan curve, TDP and undervolt
+settings that z13ctl applies itself and never writes to platform_profile, so
+profile ownership stays with your desktop. "custom" is the profile created
+automatically by the first 'fancurve --set', 'tdp --set' or 'undervolt --set'
+made while a firmware profile is active; --create makes more.
+
+Setting a fan curve, TDP or undervolt edits the profile you are running, and
+the change takes effect and persists immediately — there is no save step.
+'--profile <name>' on those commands edits a profile you are NOT running,
+which is how you build the profile that 'z13ctl autoswitch' selects on battery
+without applying it first.
+
+The firmware profile names are reserved and cannot name a custom profile.
+Custom profiles require the daemon, which is what recalls and applies them.
+
+Examples:
+  z13ctl profile --set performance
+  z13ctl profile --create battery-uv
+  z13ctl tdp --set 35 --profile battery-uv
+  z13ctl profile --set battery-uv
+  z13ctl profile --list`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		if !profileGetFlag && profileSetFlag == "" {
-			return cmd.Help()
+		switch {
+		case profileSetFlag != "":
+			return runProfileSet()
+		case profileListFlag:
+			return runProfileList()
+		case profileCreateFlag != "":
+			return runProfileCreate()
+		case profileSaveAsFlag != "":
+			return runProfileSaveAs()
+		case profileDeleteFlag != "":
+			return runProfileDelete()
+		case profileGetFlag:
+			return runProfileGet()
 		}
-
-		if profileSetFlag != "" {
-			profile := strings.ToLower(profileSetFlag)
-			switch profile {
-			case "quiet", "balanced", "performance", "custom":
-			default:
-				return fmt.Errorf("unknown profile %q: must be quiet, balanced, performance, or custom", profileSetFlag)
-			}
-
-			if dryRunFlag {
-				cli.DryRunProfile(profile)
-				return nil
-			}
-
-			// All profiles (including custom) go through the daemon if running.
-			if handled, err := api.SendProfileSet(profile); handled {
-				if err != nil {
-					return err
-				}
-				fmt.Printf("Performance profile set to %s\n", profile)
-				return nil
-			}
-
-			// "custom" without daemon: can't recall saved state, error out.
-			if profile == "custom" {
-				return fmt.Errorf("custom profile requires the daemon to recall saved settings; start the daemon first")
-			}
-
-			// Direct path (no daemon): write platform_profile, restore that
-			// profile's stock PPT, and only then release the fans to firmware
-			// auto. The firmware manages fan curves for stock profiles but does
-			// not re-apply PPT, so a previously set custom TDP would otherwise
-			// persist across the switch. Fans are released last so they are
-			// never dropped to auto while a high custom TDP is still in force —
-			// the same order as the daemon and 'tdp --reset'.
-			if err := cli.SetProfile(profile); err != nil {
-				return fmt.Errorf("setting platform profile: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
-			}
-			restoreStockPPT(profile)
-			if err := cli.ResetAllFanCurves(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: failed to reset fan curves: %v\n", err)
-			}
-			fmt.Printf("Performance profile set to %s\n", profile)
-			return nil
-		}
-
-		// --get
-		data, err := os.ReadFile(cli.FindProfilePath())
-		if err != nil {
-			return fmt.Errorf("reading platform profile: %w", err)
-		}
-		fmt.Println(strings.TrimSpace(string(data)))
-		return nil
+		return cmd.Help()
 	},
 }
 
+func runProfileSet() error {
+	profile := strings.ToLower(profileSetFlag)
+
+	if dryRunFlag {
+		cli.DryRunProfile(profile)
+		return nil
+	}
+
+	// Every profile goes through the daemon when it is running. Name validation
+	// lives there: only the daemon knows which custom profiles are saved, and
+	// it returns a message naming the profile.
+	if handled, err := api.SendProfileSet(profile); handled {
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Performance profile set to %s\n", profile)
+		return nil
+	}
+
+	// No daemon: only firmware profiles can be applied, since recalling a custom
+	// profile means reading daemon state.
+	if !cli.IsStockProfile(profile) {
+		return fmt.Errorf("custom profiles require the daemon to recall their saved settings; start the daemon first\n"+
+			"  (%q is not one of quiet, balanced, performance)", profile)
+	}
+
+	// Direct path (no daemon): write platform_profile, restore that profile's
+	// stock PPT, and only then release the fans to firmware auto. The firmware
+	// manages fan curves for stock profiles but does not re-apply PPT, so a
+	// previously set custom TDP would otherwise persist across the switch. Fans
+	// are released last so they are never dropped to auto while a high custom
+	// TDP is still in force — the same order as the daemon and 'tdp --reset'.
+	if err := cli.SetProfile(profile); err != nil {
+		return fmt.Errorf("setting platform profile: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
+	}
+	restoreStockPPT(profile)
+	if err := cli.ResetAllFanCurves(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to reset fan curves: %v\n", err)
+	}
+	fmt.Printf("Performance profile set to %s\n", profile)
+	return nil
+}
+
+func runProfileGet() error {
+	// Prefer the daemon: platform_profile is never "custom", so sysfs alone
+	// cannot report which custom profile is running.
+	if handled, st, err := api.SendGetState(); handled && err == nil && st != nil && st.Profile != "" {
+		fmt.Println(st.Profile)
+		return nil
+	}
+	data, err := os.ReadFile(cli.FindProfilePath())
+	if err != nil {
+		return fmt.Errorf("reading platform profile: %w", err)
+	}
+	fmt.Println(strings.TrimSpace(string(data)))
+	return nil
+}
+
+// profileRow mirrors the daemon's profile-list entry.
+type profileRow struct {
+	api.CustomProfile
+	Active bool `json:"active"`
+}
+
+func runProfileList() error {
+	handled, value, err := api.SendProfileList()
+	if !handled {
+		return fmt.Errorf("listing custom profiles requires the daemon; start it first")
+	}
+	if err != nil {
+		return err
+	}
+	var rows []profileRow
+	if err := json.Unmarshal([]byte(value), &rows); err != nil {
+		return fmt.Errorf("parsing profile list: %w", err)
+	}
+
+	fmt.Println("Firmware profiles: quiet, balanced, performance")
+	fmt.Println("Custom profiles:")
+	for _, r := range rows {
+		marker := " "
+		if r.Active {
+			marker = "*"
+		}
+		fmt.Printf(" %s %-20s %s\n", marker, r.Name, describeProfile(r.CustomProfile))
+	}
+	return nil
+}
+
+// describeProfile summarises which subsystems a profile controls. An empty
+// profile is worth saying out loud: it cannot be activated.
+func describeProfile(p api.CustomProfile) string {
+	var parts []string
+	if p.FanCurve != nil {
+		parts = append(parts, "fan curve")
+	}
+	if p.TDP != nil {
+		parts = append(parts, fmt.Sprintf("%dW", p.TDP.PL1SPL))
+	}
+	if p.Undervolt != nil {
+		parts = append(parts, fmt.Sprintf("CO %d", p.Undervolt.CPUCO))
+	}
+	if len(parts) == 0 {
+		return "(empty)"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func runProfileCreate() error {
+	// Validated as typed: see handleProfileCreate on why the case is not folded.
+	name := strings.TrimSpace(profileCreateFlag)
+	if err := cli.ValidateProfileName(name); err != nil {
+		return err
+	}
+	if dryRunFlag {
+		cli.DryRunProfileCreate(name)
+		return nil
+	}
+	handled, err := api.SendProfileCreate(name)
+	if !handled {
+		return fmt.Errorf("custom profiles require the daemon; start it first")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Created empty profile %s\n", name)
+	fmt.Printf("  Add settings with: z13ctl tdp --set 35 --profile %s\n", name)
+	return nil
+}
+
+func runProfileSaveAs() error {
+	name := strings.TrimSpace(profileSaveAsFlag)
+	if err := cli.ValidateProfileName(name); err != nil {
+		return err
+	}
+	if dryRunFlag {
+		cli.DryRunProfileSave(name)
+		return nil
+	}
+	handled, err := api.SendProfileSave(name)
+	if !handled {
+		return fmt.Errorf("custom profiles require the daemon; start it first")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Copied the active profile to %s\n", name)
+	return nil
+}
+
+func runProfileDelete() error {
+	name := strings.ToLower(strings.TrimSpace(profileDeleteFlag))
+	if dryRunFlag {
+		cli.DryRunProfileDelete(name)
+		return nil
+	}
+	handled, err := api.SendProfileDelete(name)
+	if !handled {
+		return fmt.Errorf("custom profiles require the daemon; start it first")
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Deleted profile %s\n", name)
+	return nil
+}
+
 func init() {
-	profileCmd.Flags().BoolVar(&profileGetFlag, "get", false, "Print the active performance profile")
-	profileCmd.Flags().StringVar(&profileSetFlag, "set", "", "Set the performance profile (quiet, balanced, performance)")
+	profileCmd.Flags().BoolVar(&profileGetFlag, "get", false, "Print the active profile")
+	profileCmd.Flags().StringVar(&profileSetFlag, "set", "", "Set the profile (quiet, balanced, performance, or a custom profile name)")
+	profileCmd.Flags().BoolVar(&profileListFlag, "list", false, "List saved custom profiles")
+	profileCmd.Flags().StringVar(&profileCreateFlag, "create", "", "Create an empty custom profile (does not activate it)")
+	profileCmd.Flags().StringVar(&profileSaveAsFlag, "save-as", "", "Copy the active custom profile under a new name")
+	profileCmd.Flags().StringVar(&profileDeleteFlag, "delete", "", "Delete a saved custom profile")
 	rootCmd.AddCommand(profileCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,66 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/dahui/z13ctl/api"
 )
+
+// profileFlagUsage is shared by the fancurve, tdp, and undervolt commands so
+// the three describe --profile identically.
+const profileFlagUsage = "Store the setting in this custom profile instead of applying it to the active one"
+
+// ensureProfileTargetSupported must be called BEFORE sending any --profile
+// edit, and is the guard against the one dangerous version skew this feature
+// has.
+//
+// The "profile" request field is additive, so a daemon from before named
+// profiles existed unmarshals the request, ignores the field it does not know,
+// and applies the setting to the running machine — then answers ok. The CLI
+// would report "stored in profile X (not applied)" over a live TDP change.
+// Probing profile-list is what distinguishes the two: an older daemon answers
+// "unknown command".
+//
+// Cost is one extra round trip, and only on the --profile path.
+func ensureProfileTargetSupported(profile string) error {
+	if profile == "" {
+		return nil
+	}
+	handled, _, err := api.SendProfileList()
+	if !handled {
+		return requireDaemonForProfile(profile)
+	}
+	if err != nil {
+		return fmt.Errorf("the running daemon does not support --profile, and would apply this setting to the\n"+
+			"  machine instead of storing it in %s; restart it after upgrading\n"+
+			"  (systemctl --user restart z13ctl)\n"+
+			"  daemon said: %w", profile, err)
+	}
+	return nil
+}
+
+// requireDaemonForProfile turns "--profile with no daemon" into an explanation
+// rather than a silent write to the running machine. Editing a profile that is
+// not active means editing daemon state, which only the daemon holds; without
+// this the direct fallback would apply the setting to hardware, which is the
+// opposite of what --profile asks for.
+func requireDaemonForProfile(profile string) error {
+	if profile == "" {
+		return nil
+	}
+	return fmt.Errorf("--profile %s requires the daemon, which stores custom profiles; start it first", profile)
+}
+
+// profileEditMessage adds a line saying the setting was stored rather than
+// applied, so a --profile edit never looks like it changed the machine.
+func profileEditMessage(profile, applied string) string {
+	if profile == "" {
+		return applied + "\n"
+	}
+	return fmt.Sprintf("Stored in profile %s (not applied — activate it with 'z13ctl profile --set %s')\n", profile, profile)
+}
 
 // Version is the current release. Override at build time:
 //

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,7 @@ package cmd
 // TDP, and battery information into a single dashboard view.
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -50,9 +51,24 @@ func runStatus() error {
 	}
 	fmt.Printf("Fans:    %s%s\n", rpmStr, modeStr)
 
-	// Performance profile.
-	profile := readCurrentProfile()
-	fmt.Printf("Profile: %s\n", profile)
+	// Performance profile. platform_profile is never a custom profile name, so
+	// the effective profile comes from the daemon when it is running; show the
+	// firmware profile underneath it when the two differ.
+	profile := effectiveProfileForTDP()
+	if hw := readCurrentProfile(); hw != profile && hw != "unknown" {
+		fmt.Printf("Profile: %s (platform: %s)\n", profile, hw)
+	} else {
+		fmt.Printf("Profile: %s\n", profile)
+	}
+
+	// Power source, and what autoswitch would select for it.
+	if onAC, err := cli.OnACPower(); err == nil {
+		source := "battery"
+		if onAC {
+			source = "AC"
+		}
+		fmt.Printf("Power:   %s%s\n", source, autoswitchNote(onAC))
+	}
 
 	// TDP power limits.
 	tdp, tdpErr := cli.ReadEffectivePPT(effectiveProfileForTDP())
@@ -92,6 +108,28 @@ func runStatus() error {
 	fmt.Printf("Battery: %s%s\n", capStr, limitStr)
 
 	return nil
+}
+
+// autoswitchNote returns a parenthetical naming the profile autoswitch selects
+// for the current source, or "" when it is off, unconfigured, or the daemon is
+// not running. Best-effort: status must not fail because autoswitch is unset.
+func autoswitchNote(onAC bool) string {
+	handled, value, err := api.SendAutoswitchGet()
+	if !handled || err != nil {
+		return ""
+	}
+	var st autoswitchStatus
+	if err := json.Unmarshal([]byte(value), &st); err != nil || !st.Enabled {
+		return ""
+	}
+	target := st.Battery
+	if onAC {
+		target = st.AC
+	}
+	if target == "" {
+		return ""
+	}
+	return " (autoswitch: " + target + ")"
 }
 
 func init() {

--- a/cmd/tdp.go
+++ b/cmd/tdp.go
@@ -16,13 +16,14 @@ import (
 )
 
 var (
-	tdpGetFlag   bool
-	tdpSetFlag   string
-	tdpResetFlag bool
-	tdpPL1Flag   string
-	tdpPL2Flag   string
-	tdpPL3Flag   string
-	tdpForceFlag bool
+	tdpGetFlag     bool
+	tdpSetFlag     string
+	tdpResetFlag   bool
+	tdpPL1Flag     string
+	tdpPL2Flag     string
+	tdpPL3Flag     string
+	tdpForceFlag   bool
+	tdpProfileFlag string
 )
 
 var tdpCmd = &cobra.Command{
@@ -66,9 +67,14 @@ When using --set, all three limits are set to the same value by default. Use
 --pl1, --pl2, and --pl3 to set them independently — for example, --set 45
 --pl2 55 --pl3 65 allows short bursts up to 65W while sustaining 45W.
 
-Setting a custom TDP switches to the "custom" profile. Switching back to a
-stock profile restores that profile's stock PPT values to hardware while
-keeping the custom values saved, so "custom" stays re-selectable.`,
+Setting a TDP edits the custom profile you are running, creating and
+activating "custom" if a firmware profile is active. Switching back to a
+firmware profile restores that profile's stock PPT values to hardware while
+keeping every custom profile saved, so they stay re-selectable.
+
+Use --profile <name> to store limits in a profile you are NOT running: nothing
+is written to hardware, which is how you build the profile 'z13ctl autoswitch'
+selects on battery.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !tdpGetFlag && tdpSetFlag == "" && !tdpResetFlag {
@@ -157,15 +163,26 @@ func runTdpSet() error {
 	}
 
 	if dryRunFlag {
+		if tdpProfileFlag != "" {
+			cli.DryRunProfileEdit(tdpProfileFlag, "power limits")
+			return nil
+		}
 		cli.DryRunTdp(watts, pl1, pl2, pl3, tdpForceFlag)
 		return nil
 	}
 
 	// The daemon applies the fan floor itself (cli.ApplyTDPSafely), so hand the
 	// whole operation over before touching hardware here.
-	if handled, err := api.SendTdpSet(tdpSetFlag, tdpPL1Flag, tdpPL2Flag, tdpPL3Flag, tdpForceFlag); handled {
+	if err := ensureProfileTargetSupported(tdpProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendTdpSetFor(tdpProfileFlag, tdpSetFlag, tdpPL1Flag, tdpPL2Flag, tdpPL3Flag, tdpForceFlag); handled {
 		if err != nil {
 			return err
+		}
+		if tdpProfileFlag != "" {
+			fmt.Print(profileEditMessage(tdpProfileFlag, ""))
+			return nil
 		}
 		if pl1 > cli.TDPMaxSafe {
 			fmt.Println("Fans set to 50%+ curve for thermal safety (the daemon keeps that floor in")
@@ -175,6 +192,9 @@ func runTdpSet() error {
 		return nil
 	}
 
+	if err := requireDaemonForProfile(tdpProfileFlag); err != nil {
+		return err
+	}
 	// Direct path: same helper, so the no-daemon path enforces the 50% fan floor
 	// on the same terms — fans first, and no TDP at all if that write fails.
 	if err := cli.ApplyTDPSafely(cli.TDPStateFor(watts, pl1, pl2, pl3)); err != nil {
@@ -193,18 +213,32 @@ func runTdpSet() error {
 
 func runTdpReset() error {
 	if dryRunFlag {
+		if tdpProfileFlag != "" {
+			cli.DryRunProfileEdit(tdpProfileFlag, "cleared power limits")
+			return nil
+		}
 		cli.DryRunTdpReset()
 		return nil
 	}
 
-	if handled, err := api.SendTdpReset(); handled {
+	if err := ensureProfileTargetSupported(tdpProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendTdpResetFor(tdpProfileFlag); handled {
 		if err != nil {
 			return err
+		}
+		if tdpProfileFlag != "" {
+			fmt.Printf("Cleared the power limits from profile %s\n", tdpProfileFlag)
+			return nil
 		}
 		fmt.Println("TDP reset: switched to balanced profile (stock PPT restored)")
 		return nil
 	}
 
+	if err := requireDaemonForProfile(tdpProfileFlag); err != nil {
+		return err
+	}
 	// Direct path (no daemon): switch to balanced, write its stock PPT values
 	// back to hardware, and only then release the fans to firmware auto — so
 	// they are never dropped to auto while a high custom TDP is still in force.
@@ -278,5 +312,6 @@ func init() {
 	tdpCmd.Flags().StringVar(&tdpPL2Flag, "pl2", "", "Override PL2/sPPT (watts)")
 	tdpCmd.Flags().StringVar(&tdpPL3Flag, "pl3", "", "Override PL3/fPPT (watts)")
 	tdpCmd.Flags().BoolVar(&tdpForceFlag, "force", false, "Allow sustained TDP (PL1) above 75W (up to 93W)")
+	tdpCmd.Flags().StringVar(&tdpProfileFlag, "profile", "", profileFlagUsage)
 	rootCmd.AddCommand(tdpCmd)
 }

--- a/cmd/undervolt.go
+++ b/cmd/undervolt.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
-	uvGetFlag   bool
-	uvSetFlag   string
-	uvResetFlag bool
+	uvGetFlag     bool
+	uvSetFlag     string
+	uvResetFlag   bool
+	uvProfileFlag string
 )
 
 var undervoltCmd = &cobra.Command{
@@ -42,7 +43,10 @@ Safety limits (matching G-Helper defaults):
 Requires the ryzen_smu kernel module (ryzen_smu-dkms-git on Arch/AUR).
 The amkillam fork is required for Strix Halo (Ryzen AI MAX+) support.
 CO values are volatile — they reset on reboot and sleep. The daemon reapplies
-them automatically on startup and resume when the custom profile is active.`,
+them automatically on startup and resume when a custom profile is active.
+
+Use --profile <name> to store an offset in a profile you are NOT running:
+nothing is applied to the CPU until you select that profile.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		if !uvGetFlag && uvSetFlag == "" && !uvResetFlag {
@@ -114,18 +118,28 @@ func runUndervoltSet() error {
 	}
 
 	if dryRunFlag {
+		if uvProfileFlag != "" {
+			cli.DryRunProfileEdit(uvProfileFlag, "Curve Optimizer offset")
+			return nil
+		}
 		cli.DryRunUndervolt(cpuOffset)
 		return nil
 	}
 
-	if handled, err := api.SendUndervoltSet(uvSetFlag); handled {
+	if err := ensureProfileTargetSupported(uvProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendUndervoltSetFor(uvProfileFlag, uvSetFlag); handled {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Curve Optimizer set: CPU %d\n", cpuOffset)
+		fmt.Print(profileEditMessage(uvProfileFlag, fmt.Sprintf("Curve Optimizer set: CPU %d", cpuOffset)))
 		return nil
 	}
 
+	if err := requireDaemonForProfile(uvProfileFlag); err != nil {
+		return err
+	}
 	if err := cli.SetCurveOptimizer(cpuOffset); err != nil {
 		return fmt.Errorf("setting curve optimizer: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
 	}
@@ -135,18 +149,28 @@ func runUndervoltSet() error {
 
 func runUndervoltReset() error {
 	if dryRunFlag {
+		if uvProfileFlag != "" {
+			cli.DryRunProfileEdit(uvProfileFlag, "cleared Curve Optimizer offset")
+			return nil
+		}
 		cli.DryRunUndervoltReset()
 		return nil
 	}
 
-	if handled, err := api.SendUndervoltReset(); handled {
+	if err := ensureProfileTargetSupported(uvProfileFlag); err != nil {
+		return err
+	}
+	if handled, err := api.SendUndervoltResetFor(uvProfileFlag); handled {
 		if err != nil {
 			return err
 		}
-		fmt.Println("Curve Optimizer reset to stock (0)")
+		fmt.Print(profileEditMessage(uvProfileFlag, "Curve Optimizer reset to stock (0)"))
 		return nil
 	}
 
+	if err := requireDaemonForProfile(uvProfileFlag); err != nil {
+		return err
+	}
 	if err := cli.ResetCurveOptimizer(); err != nil {
 		return fmt.Errorf("resetting curve optimizer: %w\n  (run 'sudo z13ctl setup' to enable non-root access)", err)
 	}
@@ -158,5 +182,6 @@ func init() {
 	undervoltCmd.Flags().BoolVar(&uvGetFlag, "get", false, "Print current Curve Optimizer offset")
 	undervoltCmd.Flags().StringVar(&uvSetFlag, "set", "", "Set all-core CPU CO offset (0 to -40)")
 	undervoltCmd.Flags().BoolVar(&uvResetFlag, "reset", false, "Reset CO to stock (0)")
+	undervoltCmd.Flags().StringVar(&uvProfileFlag, "profile", "", profileFlagUsage)
 	rootCmd.AddCommand(undervoltCmd)
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,47 @@ for range ch {
 
 ---
 
+## Custom profiles
+
+Since api v1.2.0, custom settings live in named profiles. `State.CustomProfiles`
+is the source of truth; `State.FanCurve`, `State.TDP`, and `State.Undervolt`
+remain as a projection so existing clients keep working unchanged. They carry the
+active custom profile's settings, or `custom`'s when a firmware profile is
+active — the same values selecting `custom` would recall. `Undervolt.Active` is
+what says whether an offset is applied to hardware right now.
+
+Two things to move to:
+
+**`State.Profile == "custom"` is no longer the test for custom settings.** A
+named profile makes that comparison false. Use the method instead:
+
+```go
+if state.InCustomProfile() {
+    // show the fan curve / TDP / undervolt controls
+}
+if p, ok := state.ActiveCustomProfile(); ok {
+    fmt.Println(p.Name, p.TDP)
+}
+```
+
+**Profile-targeted setters.** `SendFanCurveSet`, `SendTdpSet`, and
+`SendUndervoltSet` are unchanged and edit the active profile. The `…For`
+variants take a profile name and store the setting without applying it, which is
+how a client builds the profile `SendAutoswitchSet` selects on battery:
+
+```go
+api.SendTdpSetFor("battery-uv", "35", "", "", "", false)
+api.SendAutoswitchSet(true, "balanced", "battery-uv")
+```
+
+!!! danger "Probe before offering profile targeting"
+    The wire field behind the `…For` variants is additive, so a daemon from
+    before custom profiles drops it, **applies the setting to the running
+    machine**, and answers `ok`. Call `SendProfileList` first: an older daemon
+    answers `unknown command`, and that is the only reliable signal.
+
+---
+
 ## Socket path
 
 ```go

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -98,8 +98,8 @@ z13ctl off --device lightbar
 
 ## profile
 
-Get or set the system performance profile via the asus-wmi `platform_profile`
-sysfs interface. Root or group access required; see [setup](#setup).
+Get or set the system performance profile, and manage named custom profiles.
+Root or group access required; see [setup](#setup).
 
 ```
 z13ctl profile [flags]
@@ -107,34 +107,138 @@ z13ctl profile [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--get` | Print the active performance profile |
-| `--set <profile>` | Set the performance profile |
+| `--get` | Print the active profile |
+| `--set <profile>` | Set the profile (firmware or custom) |
+| `--list` | List saved custom profiles |
+| `--create <name>` | Create an empty custom profile (does not activate it) |
+| `--save-as <name>` | Copy the active custom profile under a new name |
+| `--delete <name>` | Delete a saved custom profile |
 
-Valid profiles: `quiet`, `balanced`, `performance`, `custom`
+### Firmware profiles
 
-The `custom` profile is a virtual profile that recalls saved fan curves and TDP
-settings from the daemon's state file. It does **not** write to `platform_profile`.
-Setting `custom` requires the daemon to be running, and at least one custom fan
-curve or TDP value must have been previously set.
+`quiet`, `balanced`, and `performance` are written to `platform_profile` via
+asus-wmi. These three names are **reserved**: a custom profile can never take
+one, so `--set balanced` always reaches the firmware profile.
 
-Setting a stock profile (`quiet`, `balanced`, `performance`) resets fan curves to
-firmware auto mode, resets the CPU undervolt to stock, and writes that profile's
-measured stock PPT values back to hardware. The firmware does *not* re-apply
-per-profile power limits on its own, so z13ctl restores them explicitly. Your
-saved custom fan curve, TDP, and undervolt are kept in daemon state, so
-`--set custom` recalls them. [`tdp --reset`](#tdp) behaves the same way, since it
-also lands on a stock profile.
+Setting a firmware profile resets fan curves to firmware auto mode, resets the
+CPU undervolt to stock, and writes that profile's measured stock PPT values back
+to hardware. The firmware does *not* re-apply per-profile power limits on its
+own, so z13ctl restores them explicitly. Your custom profiles are untouched and
+can be selected again at any time. [`tdp --reset`](#tdp) behaves the same way,
+since it also lands on a firmware profile.
+
+### Custom profiles
+
+A custom profile is z13ctl's own: a named set of fan curve, TDP, and Curve
+Optimizer settings that z13ctl applies itself. It is **never** written to
+`platform_profile`, so profile ownership stays with your desktop.
+
+`custom` is the profile created automatically by the first `fancurve --set`,
+`tdp --set`, or `undervolt --set` made while a firmware profile is active — the
+behaviour z13ctl has always had. `--create` makes more.
+
+Setting a fan curve, TDP, or undervolt edits the profile you are *running*, and
+the change takes effect and persists immediately. There is no save step;
+`--save-as` copies the active profile under a new name rather than committing
+pending edits.
+
+`--profile <name>` on [`fancurve`](#fancurve), [`tdp`](#tdp), and
+[`undervolt`](#undervolt) edits a profile you are **not** running: the setting is
+stored and nothing is applied to hardware. That is how you build the profile
+[`autoswitch`](#autoswitch) selects on battery without applying it first.
+
+Selecting a custom profile puts the machine into the state that profile
+describes. A subsystem it does not set is cleared rather than left alone — a
+profile with no fan curve releases the fans to firmware auto, one with no
+undervolt resets it, and one with no TDP hands the power limits back to the
+firmware profile underneath. That is what makes switching between two custom
+profiles predictable.
+
+Custom profiles live in daemon state, so every custom-profile operation requires
+the daemon.
 
 ```sh
 z13ctl profile --get
 z13ctl profile --set performance
-z13ctl profile --set balanced
-z13ctl profile --set custom
+
+# build a profile without applying it
+z13ctl profile --create battery-uv
+z13ctl tdp --set 35 --profile battery-uv
+z13ctl undervolt --set -25 --profile battery-uv
+
+z13ctl profile --set battery-uv    # now apply it
+z13ctl profile --list
+z13ctl profile --save-as gaming    # copy the active profile
 ```
 
+Profile names are lowercase, 1–32 characters of `a-z`, `0-9`, `-`, and `_`, and
+may not be `quiet`, `balanced`, `performance`, or `custom`.
+
 !!! note
-    When the daemon is running, setting a profile also updates
-    `power-profiles-daemon` (if installed) to the equivalent PPD profile.
+    When the daemon is running, setting a firmware profile also updates
+    `power-profiles-daemon` (if installed) to the equivalent PPD profile. Custom
+    profiles deliberately do not.
+
+!!! warning "Deleting a profile"
+    z13ctl refuses to delete the active profile or one referenced by
+    `autoswitch`. Switch away, or reconfigure autoswitch, then delete.
+
+---
+
+## autoswitch
+
+Apply a different profile automatically when the charger is plugged or
+unplugged. Requires the daemon, which watches the power source.
+
+```
+z13ctl autoswitch [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--get` | Print the configuration and the current power source |
+| `--ac <profile>` | Profile to apply on AC power |
+| `--battery <profile>` | Profile to apply on battery |
+| `--on` | Enable autoswitch with the configured targets |
+| `--off` | Disable autoswitch, keeping the configured targets |
+| `--clear` | Disable autoswitch and clear both targets |
+
+Each side takes any profile name, firmware or custom. Setting `--ac` or
+`--battery` enables autoswitch unless `--off` is given, and changes only the side
+you name — `--battery quiet` leaves the AC target as it was. An empty target
+leaves that side alone, which hands it back to your desktop's power management:
+
+```sh
+z13ctl autoswitch --ac "" --battery battery-uv
+```
+
+The full recipe, matching the most common request — a firmware profile on AC and
+a custom profile with an undervolt on battery:
+
+```sh
+z13ctl profile --create battery-uv
+z13ctl tdp --set 35 --profile battery-uv
+z13ctl undervolt --set -25 --profile battery-uv
+z13ctl autoswitch --ac balanced --battery battery-uv
+z13ctl autoswitch --get
+```
+
+Autoswitch acts **only when the power source actually changes**. A profile you
+pick by hand therefore stays in force until the next plug or unplug, and z13ctl
+does not contest the profile with `power-profiles-daemon` in between. The
+transition is applied about two seconds after the event: that settle window lets
+the desktop's own transition write land first, and stops a loose USB-C connector
+from driving a profile change per bounce.
+
+The daemon also resolves the right profile for the current power source at
+startup, so a machine that was on AC when the daemon stopped and is on battery
+when it starts lands on the battery profile directly.
+
+!!! note "GNOME's Automatic Power Saver"
+    That setting triggers on *low battery*, not on unplugging, so it can still
+    move a firmware profile after autoswitch has acted. z13ctl deliberately
+    yields between transitions rather than fighting for the profile. If you want
+    your desktop to own one side entirely, give that side an empty target.
 
 ---
 
@@ -219,6 +323,7 @@ z13ctl fancurve [flags]
 | `--get` | Print the current fan curve, mode, RPM, and APU temperature |
 | `--set <curve>` | Set a custom 8-point fan curve (applied to both fans) |
 | `--reset` | Reset both fans to firmware auto mode |
+| `--profile <name>` | Store the setting in this custom profile instead of applying it to the active one. Requires the daemon. |
 
 The **mode** in `--get` output is the one to read. `custom` means the kernel is
 honouring your curve; `auto` means it is not, regardless of which points are
@@ -305,6 +410,7 @@ z13ctl tdp [flags]
 | `--pl2 <watts>` | Override PL2/sPPT independently |
 | `--pl3 <watts>` | Override PL3/fPPT independently |
 | `--force` | Allow sustained TDP (PL1) above 75W (up to 93W). Burst limits (PL2/PL3) are allowed up to 93W without `--force`. When PL1 exceeds 75W, fans are set to a 50% minimum curve; custom curves must keep all PWM values at or above 127 (50%). |
+| `--profile <name>` | Store the setting in this custom profile instead of applying it to the active one. Requires the daemon. |
 
 **PPT attributes:**
 
@@ -397,6 +503,7 @@ z13ctl undervolt [flags]
 | `--get` | Print current CO offset (from daemon state) |
 | `--set <value>` | Set all-core CPU CO offset (0 to -40) |
 | `--reset` | Reset CPU CO to stock (0) |
+| `--profile <name>` | Store the setting in this custom profile instead of applying it to the active one. Requires the daemon. |
 
 CO values have no sysfs readback — `--get` returns the last-applied values from
 daemon state. If a stock profile is active (quiet/balanced/performance), the

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -237,7 +237,7 @@ state that would be unsafe when activated.
 | Command | Request | Response |
 |---|---|---|
 | Full state | `{"cmd":"get-state"}` | `ok`, `state` |
-| Subscribe | `{"cmd":"subscribe","events":["gui-toggle"]}` | `ok`, then streamed events |
+| Subscribe | `{"cmd":"subscribe","events":["gui-toggle","power-source","state-changed"]}` | `ok`, then streamed events |
 
 `get-state` merges persisted state with live sysfs reads — see
 [State file](#state-file).
@@ -247,6 +247,35 @@ Each streamed event is a full response object with an `event` field:
 ```json
 {"ok":true,"event":"gui-toggle"}
 ```
+
+**Events**
+
+| Event | Emitted when |
+|---|---|
+| `gui-toggle` | the Armoury Crate button is pressed |
+| `power-source` | the machine moves between mains and battery power |
+| `state-changed` | the active profile, its settings, the saved profiles, or the autoswitch configuration change |
+
+`power-source` fires on the transition itself, whether or not autoswitch is
+configured, so a client can drive a plug/battery indicator from it alone.
+
+`state-changed` fires whatever the cause — this client, another client, the CLI,
+autoswitch, or a resume. A client displaying profile, TDP, fan curve, or
+undervolt values should re-read them with `get-state` when it arrives. Lighting
+is deliberately excluded: a brightness slider drag would emit a burst of events
+describing values the client just set itself.
+
+Events carry **no payload**. The name says what happened and `get-state` answers
+with current truth — a payload would describe the moment the event was queued,
+which can already be stale by the time the client handles it.
+
+The `events` list is honoured: a client that subscribes to `gui-toggle` alone is
+never woken by the other two. Subscribing with an empty list receives everything.
+
+!!! warning "Switch on the event name"
+    While `gui-toggle` was the only event, `for range ch { toggle() }` was a
+    reasonable client loop. It is not any more — it would toggle the window on
+    every power-source change. Dispatch on the name.
 
 Discriminate on the presence of `event` — a command reply never carries it.
 (Events emitted by v1.2.0 and earlier carried `"ok":false`; clients that gate on

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -145,7 +145,49 @@ all zones. `brightness` is 0–3.
 | Set panel overdrive | `{"cmd":"paneloverdrive","set":"1"}` | `ok` |
 | Get panel overdrive | `{"cmd":"paneloverdrive-get"}` | `ok`, `value` |
 
-`profile` accepts `quiet`, `balanced`, `performance`, or the virtual `custom`.
+`profile` accepts `quiet`, `balanced`, `performance`, or the name of a custom
+profile (including `custom`).
+
+!!! warning "Unknown profile names are now rejected"
+    Earlier daemons forwarded any string to `platform_profile`. A name that is
+    neither a firmware profile nor a saved custom profile is now an error, so a
+    typo cannot reach the fan-curve reset on its way to failing. A client that
+    sent e.g. `low-power` will need updating.
+
+### Custom profiles
+
+| Command | Request | Response |
+|---|---|---|
+| Create profile | `{"cmd":"profile-create","set":"gaming"}` | `ok` |
+| Copy active profile | `{"cmd":"profile-save","set":"gaming"}` | `ok` |
+| Delete profile | `{"cmd":"profile-delete","set":"gaming"}` | `ok` |
+| List profiles | `{"cmd":"profile-list"}` | `ok`, `value` (JSON) |
+
+`profile-list` returns a JSON array of `{name, fan_curve, tdp, undervolt,
+active}`. Names are lowercase, 1–32 characters of `a-z`, `0-9`, `-`, `_`, and
+may not be a firmware profile name or `custom`; `profile-create` and
+`profile-save` validate the name as sent rather than case-folding it.
+
+`profile-delete` refuses to remove the active profile or one referenced by
+`autoswitch`.
+
+Selecting a custom profile puts hardware into the state that profile describes,
+which means a subsystem it leaves unset is **cleared**, not left alone: no fan
+curve releases the fans to firmware auto, no undervolt resets the Curve
+Optimizer, and no TDP hands the power limits back to the firmware profile
+underneath. Without that, switching between two custom profiles would leave the
+previous one's limits and offset in force, and selecting A then B then A would
+not give the same machine as selecting A.
+
+### AC/battery autoswitch
+
+| Command | Request | Response |
+|---|---|---|
+| Configure | `{"cmd":"autoswitch","enabled":true,"ac":"balanced","battery":"gaming"}` | `ok` |
+| Get | `{"cmd":"autoswitch-get"}` | `ok`, `value` (JSON: `enabled`, `ac`, `battery`, `on_ac`, `source_known`) |
+
+An empty `ac` or `battery` leaves the profile alone on that source. Both targets
+are validated against the firmware profiles and the saved custom profiles.
 
 ### Fans, TDP, and undervolt
 
@@ -164,6 +206,21 @@ all zones. `brightness` is 0–3.
 The `pl1`/`pl2`/`pl3` fields are optional overrides; `set` alone applies one
 value to all three. `force` is required for a sustained limit (PL1) above 75 W.
 
+All six commands accept an optional `profile` field naming the custom profile to
+edit. Absent or empty means the active profile — which is what every client
+written before this field existed sends, so their behaviour is unchanged. Naming
+a profile that is *not* active stores the setting and writes nothing to
+hardware; the fan-curve floor is then checked against that profile's own TDP
+rather than against the running machine, so a profile can never be stored in a
+state that would be unsafe when activated.
+
+!!! danger "The `profile` field is silently ignored by older daemons"
+    It is an additive field, so a daemon from before custom profiles unmarshals
+    the request, drops the field, **applies the setting to the running machine**,
+    and answers `ok`. A client that offers profile targeting must probe first —
+    `profile-list` answers `unknown command` on an older daemon, which is exactly
+    what `z13ctl` itself does before sending any `--profile` edit.
+
 !!! warning "Fan commands are restricted above 75 W sustained TDP"
     While PL1 is above 75 W, both fans are held to a minimum of 127 PWM (50%).
     `fancurve` is rejected if any point falls below that floor, and
@@ -173,7 +230,7 @@ value to all three. `force` is required for a sustained limit (PL1) above 75 W.
     `tdp` applies the same rule in the other direction. Raising PL1 above 75 W
     writes the high-TDP curve **first**, and if that write fails the power limit
     is not applied at all. The same holds for the daemon's own restore paths —
-    startup, resume, and `profile --set custom`.
+    startup, resume, and selecting a custom profile.
 
 ### State and events
 
@@ -237,25 +294,44 @@ The file is written atomically after every successful command. It stores:
 
 - `lighting` — mode, color, color2, speed, brightness, enabled flag
 - `devices` — per-device overrides (keyboard/lightbar can have independent state)
-- `profile` — last-set performance profile
+- `profile` — the active profile: a firmware profile, or a custom profile name
 - `battery_limit` — last-set charge limit
-- `fan_curve` — custom curve points and mode (applied to both fans)
-- `tdp` — PL1, PL2, and PL3 power limits in watts
-- `undervolt` — CPU Curve Optimizer offset and active flag (preserved across
-  profile switches for recall; `undervolt-get` includes the current profile so
-  clients can distinguish active vs saved values)
+- `custom_profiles` — saved custom profiles keyed by name, each holding its own
+  `fan_curve`, `tdp`, and `undervolt`. This is the source of truth for custom
+  settings.
+- `autoswitch` — `enabled`, and the `ac` and `battery` profile targets
+- `fan_curve`, `tdp`, `undervolt` — a **projection**, written for the benefit of
+  clients and daemons from before named profiles existed. They carry the active
+  custom profile's settings, or `custom`'s when a firmware profile is active —
+  the same values selecting `custom` would recall, which is what keeps a "saved
+  undervolt, not active" display working and what stops a downgrade taken while
+  on `balanced` from writing those settings away. They are output only;
+  `custom_profiles` is what is read back.
+
+A state file written before named profiles existed has no `custom_profiles`, so
+its top-level `fan_curve`/`tdp`/`undervolt` are migrated into a profile called
+`custom` on first load — the same settings, now addressable by name. Nothing
+needs to be done by hand.
 
 On `get-state` requests the daemon also populates `temperature` (APU die
-temperature in °C), `fan_rpm` (fan speed in RPM), and `undervolt_available`
-(whether the `ryzen_smu` kernel module is present) from live sysfs reads.
-These are not persisted — they are real-time sensor values.
+temperature in °C), `fan_rpm` (fan speed in RPM), `on_ac` (whether the charger
+is plugged in), and `undervolt_available` (whether the `ryzen_smu` kernel module
+is present) from live sysfs reads. These are not persisted — they are real-time
+sensor values.
 
-On startup the daemon reads this file and restores all saved settings before
-accepting any connections. If the last profile was `custom`, saved fan curves,
-TDP values, and undervolt offsets are re-applied to the hardware. If the last
-profile was a stock one, that profile's measured PPT values are written instead
-— the kernel's `ppt_*` attributes come up holding a stale 5 W default after
-boot, and nothing else restores them.
+On startup the daemon reads this file, resolves what the current power source
+calls for if autoswitch is configured, and restores all saved settings before
+accepting any connections. If the active profile is a custom one, its fan curve,
+TDP, and undervolt are re-applied to the hardware. If it is a firmware profile,
+that profile's measured PPT values are written instead — the kernel's `ppt_*`
+attributes come up holding a stale 5 W default after boot, and nothing else
+restores them.
+
+!!! warning "Downgrading loses named profiles"
+    A daemon from before this release reads only the top-level fields and drops
+    `custom_profiles` on its next save. The active profile's settings survive via
+    the projection above; any other saved profile does not. Copy `state.json`
+    aside before downgrading.
 
 !!! note "A corrupt state file is kept, not discarded"
     If `state.json` exists but cannot be parsed, the daemon renames it to
@@ -369,6 +445,52 @@ active, so selecting `quiet`, `balanced`, or `performance` with
     applies a curve directly. Since z13ctl 1.2.2 the command also fails with an
     error, rather than reporting success, if the kernel refuses to honour the
     curve it just wrote.
+
+---
+
+## AC/battery autoswitch
+
+When [`z13ctl autoswitch`](commands.md#autoswitch) is configured, the daemon
+applies the profile that matches the power source on every plug and unplug.
+
+The watcher is **edge-triggered** on the mains adapter's `online` attribute
+under `/sys/class/power_supply`, and never reads or writes `platform_profile`.
+That is what makes it safe to run alongside `power-profiles-daemon`: it reacts
+only to a value that neither z13ctl nor PPD nor the desktop can write, so the
+feedback loop that would produce a write-fight does not exist. The visible
+consequence, and the intended semantics, is that a profile you choose by hand
+stays in force until the power source actually changes.
+
+Detection uses two triggers and one observation. UPower's `OnBattery` property
+wakes the watcher immediately where UPower is running; a 2-second poll is the
+backstop that keeps this working in Steam Gaming Mode, on a bare session, or
+wherever UPower is absent. Either way the answer comes from sysfs, so there is
+one behaviour to reason about.
+
+A transition is confirmed on the following observation before anything is
+applied, so a change lands about two seconds after the event. That settle window
+lets the desktop's own transition write land first — a custom fan curve would
+otherwise be dropped in the gap before the [reconciler](#custom-fan-curve-reconciliation)
+notices — and stops a loose USB-C connector from driving a full power-limit, fan,
+and SMU write per bounce.
+
+Devices are selected by their `type` file, not by having an `online` file. On the
+Z13 the detachable keyboard registers as `hid-*-battery-N` and the USB-C ports as
+`ucsi-source-psy-*`, and all of them expose `online`; only `type` `Mains` is the
+charger. If no `Mains` supply exists at all — a VM, a desktop, a driver not yet
+bound — the source is treated as *unknown* and the watcher does nothing, rather
+than concluding the machine is on battery.
+
+There is deliberately no autoswitch hook in the resume path. Go timers do not
+advance across suspend, so the watcher's armed timer fires promptly after resume
+and handles an unplug-during-sleep on its own; duplicating the logic would race
+it and apply twice for one event.
+
+!!! note "GNOME's Automatic Power Saver"
+    That setting triggers on low battery rather than on unplugging, so it can
+    still move a firmware profile after autoswitch has acted. z13ctl yields
+    between transitions by design. Give a side an empty target to hand it to your
+    desktop entirely.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,22 +170,64 @@ Safety limit (matching G-Helper defaults): CPU 0 to -40.
 
 ---
 
-## Custom profile
+## Custom profiles
 
-The `custom` profile recalls previously saved fan curves, TDP, and undervolt
-settings from the daemon's state. At least one custom fan curve, TDP value, or
-undervolt offset must have been previously set.
+A custom profile is a named set of fan curve, TDP, and undervolt settings that
+z13ctl applies itself. The first custom setting you make while a firmware
+profile is active creates one called `custom`:
 
 ```sh
-# Set up a custom configuration
 z13ctl fancurve --set "48:2,53:22,57:30,60:43,63:56,65:68,70:89,76:102"
 z13ctl tdp --set 50
 
-# Recall it later with custom profile
+# Recall it later
 z13ctl profile --set custom
 
-# Switch back to a stock profile (resets fan curves and TDP)
+# Switch back to a firmware profile (resets fan curves and TDP)
 z13ctl profile --set balanced
+```
+
+Editing a setting changes the profile you are running and persists immediately —
+there is no save step. Give a setup its own name with `--create`, or copy the one
+you are running with `--save-as`:
+
+```sh
+z13ctl profile --save-as quiet-work
+z13ctl profile --list
+```
+
+Requires the daemon, which is what stores and recalls custom profiles.
+
+---
+
+## A different profile on AC and battery
+
+Build the profile you want on battery first. `--profile` stores a setting in a
+profile you are *not* running, so nothing is applied to the machine while you set
+it up:
+
+```sh
+z13ctl profile --create battery-uv
+z13ctl tdp --set 35 --profile battery-uv
+z13ctl undervolt --set -25 --profile battery-uv
+```
+
+Then hand the pair to the daemon:
+
+```sh
+z13ctl autoswitch --ac balanced --battery battery-uv
+z13ctl autoswitch --get
+```
+
+Unplug the charger and the battery profile takes effect a couple of seconds
+later; plug it back in and you are on `balanced` again. A profile you pick by
+hand in between stays until the next plug or unplug.
+
+To hand one side back to your desktop's power management, leave its target
+empty:
+
+```sh
+z13ctl autoswitch --ac "" --battery battery-uv
 ```
 
 ---

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -78,9 +78,18 @@ func DryRunBatteryLimit(limit int) {
 // including mapped names for secondary devices (e.g. amd-pmf uses "low-power" not "quiet").
 func DryRunProfile(profile string) {
 	fmt.Println("=== DRY RUN (no sysfs write) ===")
-	if _, ok := StockProfilePPT[profile]; ok {
-		fmt.Println("Would reset the CPU Curve Optimizer to stock")
+
+	// A custom profile is never written to platform_profile — this printed the
+	// name as a platform_profile write for every release up to now, describing
+	// something the daemon has never done.
+	if !IsStockProfile(profile) {
+		fmt.Printf("Would recall custom profile %q from daemon state and apply its\n", profile)
+		fmt.Println("  saved fan curve, TDP, and Curve Optimizer offset")
+		fmt.Println("Would NOT write platform_profile (custom profiles leave it to the desktop)")
+		return
 	}
+
+	fmt.Println("Would reset the CPU Curve Optimizer to stock")
 	primary := FindProfilePath()
 	// Name-mapped, as SetProfile does for every device including the primary —
 	// printing the raw name here showed "quiet" where "low-power" gets written.
@@ -118,6 +127,68 @@ func DryRunProfile(profile string) {
 			profile, stock.PL1SPL, stock.PL2SPPT, stock.FPPT, stock.APUSPPT, stock.PlatformSPPT)
 		fmt.Printf("Would reset fan curves to auto (pwm_enable=2)\n")
 	}
+}
+
+// DryRunProfileEdit prints what storing a setting in a profile that is not
+// running would do. Nothing reaches hardware on that path, so printing the
+// ordinary sysfs write list would describe the opposite of what happens.
+func DryRunProfileEdit(profile, setting string) {
+	fmt.Println("=== DRY RUN (no sysfs write) ===")
+	fmt.Printf("Would store the %s in custom profile %q in daemon state\n", setting, profile)
+	fmt.Println("Would NOT write hardware — the setting takes effect when that profile")
+	fmt.Printf("  is activated: z13ctl profile --set %s\n", profile)
+}
+
+// DryRunProfileCreate prints what creating an empty custom profile would do.
+// Custom profiles live in daemon state, not sysfs, so there is nothing to write.
+func DryRunProfileCreate(name string) {
+	fmt.Println("=== DRY RUN (no sysfs write) ===")
+	fmt.Printf("Would create empty custom profile %q in daemon state\n", name)
+	fmt.Println("Would NOT change the active profile or touch hardware")
+}
+
+// DryRunProfileSave prints what copying the active profile would do.
+func DryRunProfileSave(name string) {
+	fmt.Println("=== DRY RUN (no sysfs write) ===")
+	fmt.Printf("Would copy the active custom profile to %q in daemon state\n", name)
+	fmt.Println("Would NOT change the active profile or touch hardware")
+}
+
+// DryRunProfileDelete prints what deleting a custom profile would do.
+func DryRunProfileDelete(name string) {
+	fmt.Println("=== DRY RUN (no sysfs write) ===")
+	fmt.Printf("Would delete custom profile %q from daemon state\n", name)
+	fmt.Println("  (refused if it is the active profile or referenced by autoswitch)")
+}
+
+// DryRunAutoswitch prints the AC/battery configuration that would be stored.
+// It stores configuration only — the daemon applies a profile on the next
+// power-source transition, not now.
+func DryRunAutoswitch(enabled bool, ac, battery string) {
+	fmt.Println("=== DRY RUN (no sysfs write) ===")
+	if !enabled {
+		fmt.Println("Would disable AC/battery autoswitching in daemon state")
+		return
+	}
+	fmt.Printf("Would store autoswitch in daemon state: AC=%s battery=%s\n",
+		dryRunTarget(ac), dryRunTarget(battery))
+	fmt.Printf("Would read the power source from %s\n", dryRunACPath())
+	fmt.Println("Would NOT change the profile now — the daemon applies one on the next")
+	fmt.Println("  plug or unplug")
+}
+
+func dryRunTarget(name string) string {
+	if name == "" {
+		return "(unchanged)"
+	}
+	return name
+}
+
+func dryRunACPath() string {
+	if p := FindACOnlinePath(); p != "" {
+		return p
+	}
+	return "(no mains power supply found)"
 }
 
 // DryRunBootSound prints the sysfs write that would be performed for a boot sound change.

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -61,6 +61,41 @@ func TestDryRunProfile(t *testing.T) {
 	}
 }
 
+// TestDryRunProfileCustomDoesNotClaimAPlatformProfileWrite is the regression
+// guard for a long-standing lie: the dry run printed
+// `Would write "custom" to /sys/.../profile` for a custom profile, which the
+// daemon has never done — custom profiles deliberately leave platform_profile
+// to the desktop.
+func TestDryRunProfileCustomDoesNotClaimAPlatformProfileWrite(t *testing.T) {
+	for _, name := range []string{"custom", "battery-uv"} {
+		out := captureStdout(t, func() { cli.DryRunProfile(name) })
+		if strings.Contains(out, "Would write") {
+			t.Errorf("DryRunProfile(%q) claims a sysfs write:\n%s", name, out)
+		}
+		if !strings.Contains(out, name) {
+			t.Errorf("DryRunProfile(%q) does not name the profile:\n%s", name, out)
+		}
+	}
+}
+
+func TestDryRunAutoswitch(t *testing.T) {
+	out := captureStdout(t, func() { cli.DryRunAutoswitch(true, "balanced", "battery-uv") })
+	for _, want := range []string{"DRY RUN", "balanced", "battery-uv"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DryRunAutoswitch output missing %q:\n%s", want, out)
+		}
+	}
+	// Configuration only: it must not read as having changed the profile.
+	if strings.Contains(out, "Would write") {
+		t.Errorf("DryRunAutoswitch claims a sysfs write:\n%s", out)
+	}
+
+	off := captureStdout(t, func() { cli.DryRunAutoswitch(false, "balanced", "battery-uv") })
+	if !strings.Contains(off, "disable") {
+		t.Errorf("DryRunAutoswitch(false, ...) does not say it disables autoswitch:\n%s", off)
+	}
+}
+
 func TestDryRunOff(t *testing.T) {
 	out := captureStdout(t, cli.DryRunOff)
 

--- a/internal/cli/power.go
+++ b/internal/cli/power.go
@@ -1,0 +1,127 @@
+package cli
+
+// power.go — mains/battery power source discovery, and the profile-name rules
+// shared by cmd/ and internal/daemon/.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dahui/z13ctl/api"
+)
+
+// FindACOnlinePath returns the sysfs "online" path of the mains adapter, or ""
+// when no Mains power supply is present.
+//
+// Devices must be selected by their type file, never by merely having an
+// "online" file. On the Z13 the detachable keyboard registers as
+// hid-*-battery-N (type Battery) and the two USB-C ports as ucsi-source-psy-*
+// (type USB), and all of them expose "online" — so a */online glob picks up the
+// keyboard's battery and reports "on AC" whenever the cover is attached.
+func FindACOnlinePath() string {
+	paths := mainsOnlinePaths()
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}
+
+// mainsOnlinePaths returns the "online" path of every Mains power supply, in
+// directory order. There is normally one, but a dock can add a second.
+func mainsOnlinePaths() []string {
+	entries, err := os.ReadDir(sysPowerSupplyDir)
+	if err != nil {
+		return nil
+	}
+	var paths []string
+	for _, e := range entries {
+		base := sysPowerSupplyDir + "/" + e.Name()
+		data, err := os.ReadFile(base + "/type")
+		if err != nil || strings.TrimSpace(string(data)) != "Mains" {
+			continue
+		}
+		online := base + "/online"
+		if _, err := os.Stat(online); err != nil {
+			continue
+		}
+		paths = append(paths, online)
+	}
+	return paths
+}
+
+// OnACPower reports whether the machine is running on mains power.
+//
+// It returns an error when no Mains supply exists — a VM, a desktop, or the
+// ACPI driver not yet bound. Callers must treat that as *unknown* and take no
+// action; reading it as "on battery" would have the daemon apply the battery
+// profile to a machine that has no battery.
+func OnACPower() (bool, error) {
+	paths := mainsOnlinePaths()
+	if len(paths) == 0 {
+		return false, fmt.Errorf("no mains power supply found under %s", sysPowerSupplyDir)
+	}
+	var lastErr error
+	read := false
+	for _, p := range paths {
+		v, err := readIntFile(p)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		read = true
+		// Any online adapter means mains power: a dock and the bundled charger
+		// both register, and only the one actually plugged in reads 1.
+		if v != 0 {
+			return true, nil
+		}
+	}
+	if !read {
+		return false, fmt.Errorf("reading mains power state: %w", lastErr)
+	}
+	return false, nil
+}
+
+// IsStockProfile reports whether name is one of the firmware performance
+// profiles that can be written to platform_profile.
+func IsStockProfile(name string) bool { return api.IsStockProfileName(name) }
+
+// maxProfileNameLen bounds a custom profile name. It is a state file key and a
+// command-line argument, not a display string; anything longer is a mistake.
+const maxProfileNameLen = 32
+
+// ValidateProfileName checks a user-supplied custom profile name.
+//
+// The firmware profile names are reserved so that selecting one always reaches
+// the firmware profile and can never be shadowed by a custom profile. That
+// reservation is load-bearing beyond avoiding confusion: ReadEffectivePPT
+// treats any name absent from StockProfilePPT as custom and disables its
+// stale-5W fallback, which is right for a custom profile and wrong for a stock
+// one — so a custom profile called "balanced" would misreport the machine's
+// power limits. "custom" is reserved separately: it is the profile created
+// implicitly by the first custom setting.
+func ValidateProfileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name must not be empty")
+	}
+	if name != strings.ToLower(name) {
+		return fmt.Errorf("profile name %q must be lowercase", name)
+	}
+	if IsStockProfile(name) {
+		return fmt.Errorf("%q is a firmware profile name and cannot be used for a custom profile", name)
+	}
+	if name == api.DefaultCustomProfile {
+		return fmt.Errorf("%q is reserved for the profile created by the first custom setting", name)
+	}
+	if len(name) > maxProfileNameLen {
+		return fmt.Errorf("profile name %q is longer than %d characters", name, maxProfileNameLen)
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return fmt.Errorf("profile name %q may only contain a-z, 0-9, '-' and '_'", name)
+		}
+	}
+	return nil
+}

--- a/internal/cli/power_test.go
+++ b/internal/cli/power_test.go
@@ -1,0 +1,180 @@
+package cli
+
+// power_test.go — mains discovery and profile-name rules, against the fake
+// sysfs tree. The decoy devices seeded by newFakeSysfs are the point of most of
+// these cases: on a real Z13 the detachable keyboard and the USB-C ports both
+// expose an "online" file, so anything that globs */online reports mains power
+// whenever the cover is attached.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dahui/z13ctl/api"
+)
+
+func TestFindACOnlinePathIgnoresNonMainsSupplies(t *testing.T) {
+	f := newFakeSysfs(t)
+
+	got := FindACOnlinePath()
+	want := f.ac + "/online"
+	if got != want {
+		t.Fatalf("FindACOnlinePath() = %q, want %q", got, want)
+	}
+	// Guard the premise: the decoys really are present and really do have an
+	// online file, or this test passes for the wrong reason.
+	for _, decoy := range []string{
+		"hid-0018:04F3:43C7.0008-battery-7",
+		"ucsi-source-psy-USBC000:001",
+	} {
+		p := f.root + "/power_supply/" + decoy + "/online"
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("decoy %s has no online file: %v", decoy, err)
+		}
+	}
+}
+
+func TestOnACPower(t *testing.T) {
+	f := newFakeSysfs(t)
+
+	f.setACOnline(t, true)
+	on, err := OnACPower()
+	if err != nil || !on {
+		t.Errorf("OnACPower() with the adapter plugged = (%v, %v), want (true, nil)", on, err)
+	}
+
+	f.setACOnline(t, false)
+	on, err = OnACPower()
+	if err != nil || on {
+		t.Errorf("OnACPower() with the adapter unplugged = (%v, %v), want (false, nil) — a decoy's online=1 leaked through", on, err)
+	}
+}
+
+func TestOnACPowerAnyMainsOnlineWins(t *testing.T) {
+	f := newFakeSysfs(t)
+	f.setACOnline(t, false)
+	// A dock registers as a second Mains supply.
+	f.writeFile(t, f.root+"/power_supply/ADP1/type", "Mains")
+	f.writeFile(t, f.root+"/power_supply/ADP1/online", "1")
+
+	on, err := OnACPower()
+	if err != nil || !on {
+		t.Errorf("OnACPower() with a second adapter online = (%v, %v), want (true, nil)", on, err)
+	}
+}
+
+// TestOnACPowerWithNoMainsSupply pins the contract the watcher depends on: no
+// adapter is *unknown*, not "on battery". Returning false here would have the
+// daemon apply the battery profile on a machine that has no battery.
+func TestOnACPowerWithNoMainsSupply(t *testing.T) {
+	f := newFakeSysfs(t)
+	if err := os.RemoveAll(f.ac); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := OnACPower(); err == nil {
+		t.Error("OnACPower() with no Mains supply = nil error, want an error so callers treat the source as unknown")
+	}
+}
+
+func TestOnACPowerWithUnreadableOnline(t *testing.T) {
+	f := newFakeSysfs(t)
+	f.writeFile(t, f.ac+"/online", "not-a-number")
+
+	if _, err := OnACPower(); err == nil {
+		t.Error("OnACPower() with a garbage online value = nil error, want an error")
+	}
+}
+
+func TestValidateProfileName(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"plain", "gaming", false},
+		{"digits and separators", "battery-uv_2", false},
+		{"empty", "", true},
+		{"uppercase", "Gaming", true},
+		{"stock quiet", "quiet", true},
+		{"stock balanced", "balanced", true},
+		{"stock performance", "performance", true},
+		{"reserved custom", "custom", true},
+		{"stock name with different case", "Balanced", true},
+		{"leading space", " gaming", true},
+		{"trailing space", "gaming ", true},
+		{"space inside", "my profile", true},
+		{"punctuation", "gaming!", true},
+		{"slash would escape the state map", "a/b", true},
+		{"too long", strings.Repeat("a", maxProfileNameLen+1), true},
+		{"at the length limit", strings.Repeat("a", maxProfileNameLen), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProfileName(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProfileName(%q) = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestNoStockProfileNameIsAcceptedAsCustom is the invariant ReadEffectivePPT
+// silently relies on: it treats any name absent from StockProfilePPT as custom
+// and disables its stale-5W fallback, so a custom profile named "balanced"
+// would make the machine misreport its power limits.
+func TestNoStockProfileNameIsAcceptedAsCustom(t *testing.T) {
+	for name := range StockProfilePPT {
+		if !IsStockProfile(name) {
+			t.Errorf("IsStockProfile(%q) = false, but it is a key in StockProfilePPT", name)
+		}
+		if err := ValidateProfileName(name); err == nil {
+			t.Errorf("ValidateProfileName(%q) = nil, want an error — a custom profile may not shadow a firmware profile", name)
+		}
+		var s api.State
+		if s.IsCustomProfile(name) {
+			t.Errorf("State.IsCustomProfile(%q) = true, want false", name)
+		}
+	}
+}
+
+// TestIsCustomProfileIgnoresAShadowingMapEntry covers the hand-edited state
+// file: even with a "balanced" entry in the profile map, the firmware profile
+// must win.
+func TestIsCustomProfileIgnoresAShadowingMapEntry(t *testing.T) {
+	s := api.State{CustomProfiles: map[string]api.CustomProfile{
+		"balanced": {Name: "balanced"},
+		"gaming":   {Name: "gaming"},
+	}}
+	if s.IsCustomProfile("balanced") {
+		t.Error("IsCustomProfile(\"balanced\") = true, want false even with a map entry of that name")
+	}
+	if !s.IsCustomProfile("gaming") {
+		t.Error("IsCustomProfile(\"gaming\") = false, want true")
+	}
+	if !s.IsCustomProfile(api.DefaultCustomProfile) {
+		t.Error("IsCustomProfile(\"custom\") = false, want true even with no map entry")
+	}
+	if s.IsCustomProfile("never-saved") {
+		t.Error("IsCustomProfile(\"never-saved\") = true, want false")
+	}
+}
+
+func TestCheckCurveAgainstTDP(t *testing.T) {
+	below := []api.FanCurvePoint{{Temp: 30, PWM: HighTDPMinPWM - 1}, {Temp: 40, PWM: 255}}
+	above := []api.FanCurvePoint{{Temp: 30, PWM: HighTDPMinPWM}, {Temp: 40, PWM: 255}}
+
+	if err := CheckCurveAgainstTDP(below, TDPMaxSafe); err != nil {
+		t.Errorf("CheckCurveAgainstTDP(below floor, %dW) = %v, want nil — the floor only applies above the safe max", TDPMaxSafe, err)
+	}
+	if err := CheckCurveAgainstTDP(below, TDPMaxSafe+1); err == nil {
+		t.Errorf("CheckCurveAgainstTDP(below floor, %dW) = nil, want an error", TDPMaxSafe+1)
+	}
+	if err := CheckCurveAgainstTDP(above, TDPMaxSafe+1); err != nil {
+		t.Errorf("CheckCurveAgainstTDP(at floor, %dW) = %v, want nil", TDPMaxSafe+1, err)
+	}
+	if err := CheckCurveAgainstTDP(nil, TDPMaxSafe+1); err != nil {
+		t.Errorf("CheckCurveAgainstTDP(nil, %dW) = %v, want nil — a profile with no curve imposes no floor of its own", TDPMaxSafe+1, err)
+	}
+}

--- a/internal/cli/sysfs_fake_test.go
+++ b/internal/cli/sysfs_fake_test.go
@@ -22,8 +22,19 @@ type fakeSysfs struct {
 	ppt        string
 	smu        string
 	battery    string
+	ac         string // the Mains power supply device
 	firmware   string
 	ppdCalls   *[]string // powerprofilesctl profiles the stub recorded
+}
+
+// setACOnline flips the mains adapter between plugged and unplugged.
+func (f *fakeSysfs) setACOnline(t *testing.T, online bool) {
+	t.Helper()
+	v := "0"
+	if online {
+		v = "1"
+	}
+	f.writeFile(t, f.ac+"/online", v)
 }
 
 // newFakeSysfs builds the tree and redirects every path var for the test's
@@ -53,6 +64,19 @@ func newFakeSysfs(t *testing.T) *fakeSysfs {
 	f.writeFile(t, f.hwmon+"/name", hwmonNameCurves)
 	f.writeFile(t, f.hwmonRead+"/name", hwmonNameReadings)
 	f.writeFile(t, f.hwmonTemp+"/name", "k10temp")
+
+	// The mains adapter, plus the two decoys that also carry an "online" file on
+	// a real Z13: the detachable keyboard's HID battery and a USB-C PD source.
+	// Any helper that globs */online instead of filtering on type picks these up
+	// and reports mains power whenever the cover is attached.
+	f.ac = root + "/power_supply/AC0"
+	f.writeFile(t, f.ac+"/type", "Mains")
+	f.writeFile(t, f.ac+"/online", "1")
+	f.writeFile(t, f.battery+"/type", "Battery")
+	f.writeFile(t, root+"/power_supply/hid-0018:04F3:43C7.0008-battery-7/type", "Battery")
+	f.writeFile(t, root+"/power_supply/hid-0018:04F3:43C7.0008-battery-7/online", "1")
+	f.writeFile(t, root+"/power_supply/ucsi-source-psy-USBC000:001/type", "USB")
+	f.writeFile(t, root+"/power_supply/ucsi-source-psy-USBC000:001/online", "1")
 
 	// Never shell out to the live power-profiles-daemon from a test.
 	origPPD := ppdRunner

--- a/internal/cli/tdp.go
+++ b/internal/cli/tdp.go
@@ -205,7 +205,23 @@ func ApplyTDPSafely(s api.TDPState) error {
 // unavailable when sysfs cannot be read at all.
 func CheckFanCurveFloor(profile string, points []api.FanCurvePoint) error {
 	tdp, err := ReadEffectivePPT(profile)
-	if err != nil || tdp.PL1SPL <= TDPMaxSafe {
+	if err != nil {
+		return nil
+	}
+	return CheckCurveAgainstTDP(points, tdp.PL1SPL)
+}
+
+// CheckCurveAgainstTDP rejects a curve holding any point below HighTDPMinPWM
+// while pl1 is above TDPMaxSafe. It reads nothing, which is what makes it usable
+// for a custom profile that is not currently applied: hardware says nothing
+// about a profile that is not running, so the limit to check against is the one
+// stored in the same profile.
+//
+// Applying that check when a profile is *edited* means no profile can be saved
+// in a state that would be unsafe when it is later activated. ApplyTDPSafely
+// still fails closed at activation; this is the earlier, friendlier refusal.
+func CheckCurveAgainstTDP(points []api.FanCurvePoint, pl1 int) error {
+	if pl1 <= TDPMaxSafe {
 		return nil
 	}
 	for _, p := range points {
@@ -227,9 +243,21 @@ func CheckFanCurveFloor(profile string, points []api.FanCurvePoint) error {
 // As with CheckFanCurveFloor, a PPT read failure is not a refusal.
 func CheckFanFloorRelease(profile string) error {
 	tdp, err := ReadEffectivePPT(profile)
-	if err != nil || tdp.PL1SPL <= TDPMaxSafe {
+	if err != nil {
+		return nil
+	}
+	return CheckFanFloorReleaseAt(tdp.PL1SPL)
+}
+
+// CheckFanFloorReleaseAt is CheckFanFloorRelease against a known sustained
+// limit rather than one read from hardware. It is what a custom profile that is
+// not currently applied has to be checked against: hardware says nothing about
+// a profile that is not running, and clearing the curve from a profile that
+// keeps a high limit would be unsafe the moment that profile is activated.
+func CheckFanFloorReleaseAt(pl1 int) error {
+	if pl1 <= TDPMaxSafe {
 		return nil
 	}
 	return fmt.Errorf("sustained TDP is %dW (above %dW), so fans must stay at or above %d PWM; lower it first with 'z13ctl tdp --reset'",
-		tdp.PL1SPL, TDPMaxSafe, HighTDPMinPWM)
+		pl1, TDPMaxSafe, HighTDPMinPWM)
 }

--- a/internal/daemon/clone_test.go
+++ b/internal/daemon/clone_test.go
@@ -30,6 +30,23 @@ func sampleState() api.State {
 			Mode:   1,
 			Points: []api.FanCurvePoint{{Temp: 40, PWM: 50}, {Temp: 50, PWM: 80}},
 		},
+		Autoswitch: &api.AutoswitchState{Enabled: true, AC: "balanced", Battery: "battery-uv"},
+		CustomProfiles: map[string]api.CustomProfile{
+			"custom": {
+				Name:      "custom",
+				TDP:       &api.TDPState{PL1SPL: 15, PL2SPPT: 20, FPPT: 25, APUSPPT: 20, PlatformSPPT: 20},
+				Undervolt: &api.UndervoltState{CPUCO: -20, Active: true},
+				FanCurve: &api.FanCurveState{
+					Mode:   1,
+					Points: []api.FanCurvePoint{{Temp: 40, PWM: 50}, {Temp: 50, PWM: 80}},
+				},
+			},
+			"battery-uv": {
+				Name:      "battery-uv",
+				TDP:       &api.TDPState{PL1SPL: 35, PL2SPPT: 40, FPPT: 45},
+				Undervolt: &api.UndervoltState{CPUCO: -25},
+			},
+		},
 	}
 }
 
@@ -58,6 +75,88 @@ func TestCloneStateSharesNoMutableMemory(t *testing.T) {
 	}
 	if orig.FanCurve.Points[0].PWM != 50 {
 		t.Errorf("original FanCurve.Points[0].PWM = %d, want 50 — the slice is shared", orig.FanCurve.Points[0].PWM)
+	}
+}
+
+// TestCloneStateDeepCopiesCustomProfiles is the guard for the riskiest part of
+// named profiles: a new map header is not enough, because each entry carries
+// three pointers and a slice. A shallow entry copy reproduces exactly the
+// concurrent map/pointer mutation that the Go runtime turns into an
+// unrecoverable crash rather than a catchable panic.
+func TestCloneStateDeepCopiesCustomProfiles(t *testing.T) {
+	orig := sampleState()
+	c := cloneState(orig)
+
+	c.CustomProfiles["custom"].TDP.PL1SPL = 99
+	c.CustomProfiles["custom"].FanCurve.Points[0].PWM = 255
+	c.CustomProfiles["battery-uv"].Undervolt.CPUCO = -1
+	c.CustomProfiles["added"] = api.CustomProfile{Name: "added"}
+	c.Autoswitch.Battery = "something-else"
+
+	if orig.CustomProfiles["custom"].TDP.PL1SPL != 15 {
+		t.Errorf("original profile TDP = %d, want 15 — the entry's pointer is shared",
+			orig.CustomProfiles["custom"].TDP.PL1SPL)
+	}
+	if orig.CustomProfiles["custom"].FanCurve.Points[0].PWM != 50 {
+		t.Errorf("original profile curve point = %d, want 50 — the entry's slice is shared",
+			orig.CustomProfiles["custom"].FanCurve.Points[0].PWM)
+	}
+	if orig.CustomProfiles["battery-uv"].Undervolt.CPUCO != -25 {
+		t.Errorf("original profile CO = %d, want -25 — the entry's pointer is shared",
+			orig.CustomProfiles["battery-uv"].Undervolt.CPUCO)
+	}
+	if _, ok := orig.CustomProfiles["added"]; ok {
+		t.Error("a key added to the clone appeared in the original — the map is shared")
+	}
+	if orig.Autoswitch.Battery != "battery-uv" {
+		t.Errorf("original Autoswitch.Battery = %q, want \"battery-uv\" — the pointer is shared", orig.Autoswitch.Battery)
+	}
+}
+
+// TestWithLegacyProjection covers the compatibility shim: CustomProfiles is the
+// truth, and the top-level fields are filled in from the active profile only at
+// the serialization boundaries so clients written before named profiles existed
+// keep seeing the settings that are in force.
+func TestWithLegacyProjection(t *testing.T) {
+	s := api.State{
+		Profile: "battery-uv",
+		CustomProfiles: map[string]api.CustomProfile{
+			"battery-uv": {Name: "battery-uv", TDP: &api.TDPState{PL1SPL: 35}},
+		},
+	}
+	got := withLegacyProjection(s)
+	if got.TDP == nil || got.TDP.PL1SPL != 35 {
+		t.Errorf("projected TDP = %+v, want the active profile's 35W", got.TDP)
+	}
+	if got.FanCurve != nil || got.Undervolt != nil {
+		t.Error("projected fields the active profile does not set")
+	}
+
+	// On a firmware profile the projection falls back to "custom" — what a bare
+	// "undervolt --set" edits and "profile --set custom" recalls. Projecting
+	// nothing would lose the saved-but-inactive undervolt a GUI displays, and
+	// would write those settings away on a downgrade taken while on balanced.
+	s.Profile = "balanced"
+	s.TDP = &api.TDPState{PL1SPL: 99} // a stale projection from an earlier active profile
+	s.CustomProfiles[api.DefaultCustomProfile] = api.CustomProfile{
+		Name:      api.DefaultCustomProfile,
+		Undervolt: &api.UndervoltState{CPUCO: -20},
+	}
+	got = withLegacyProjection(s)
+	if got.TDP != nil {
+		t.Errorf("projected TDP = %+v, want nil — \"custom\" holds no TDP", got.TDP)
+	}
+	if got.Undervolt == nil || got.Undervolt.CPUCO != -20 {
+		t.Errorf("projected undervolt = %+v, want the saved -20 offset", got.Undervolt)
+	}
+	if got.Undervolt != nil && got.Undervolt.Active {
+		t.Error("the projection reads as applied while a firmware profile is active")
+	}
+
+	// Nothing saved at all: the fields stay nil rather than becoming zero values.
+	got = withLegacyProjection(api.State{Profile: "balanced"})
+	if got.FanCurve != nil || got.TDP != nil || got.Undervolt != nil {
+		t.Errorf("projection invented fields with nothing saved: %+v", got)
 	}
 }
 
@@ -91,6 +190,9 @@ func TestCloneStateHandlesNilFields(t *testing.T) {
 	c := cloneState(api.State{Profile: "balanced"})
 	if c.Devices != nil || c.TDP != nil || c.Undervolt != nil || c.FanCurve != nil {
 		t.Errorf("cloneState() populated nil fields: %+v", c)
+	}
+	if c.CustomProfiles != nil || c.Autoswitch != nil {
+		t.Errorf("cloneState() populated nil profile fields: %+v", c)
 	}
 	if c.Profile != "balanced" {
 		t.Errorf("Profile = %q, want \"balanced\"", c.Profile)
@@ -128,6 +230,13 @@ func TestSaveStateSnapshotIsRaceFree(t *testing.T) {
 				d.state.Devices["lightbar"] = api.LightingState{Brightness: i % 4}
 				d.state.Undervolt.Active = i%2 == 0
 				d.state.FanCurve.Points[0].PWM = i % 256
+				// The profile map is mutated by every setting handler and by the
+				// autoswitch watcher, through both the map header and the
+				// pointers inside each entry.
+				d.state.CustomProfiles["custom"].TDP.PL1SPL = 10 + i%40
+				d.state.CustomProfiles["custom"].FanCurve.Points[0].PWM = i % 256
+				setUndervoltActive(d.state, i%2 == 0)
+				d.state.Autoswitch.Battery = "battery-uv"
 				d.mu.Unlock()
 			}
 		}()

--- a/internal/daemon/clone_test.go
+++ b/internal/daemon/clone_test.go
@@ -253,7 +253,7 @@ func TestBroadcastEventShape(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	d := &Daemon{}
-	d.addSubscriber(server)
+	d.addSubscriber(server, nil)
 
 	go d.broadcast(response{OK: true, Event: "gui-toggle"})
 
@@ -285,8 +285,8 @@ func TestBroadcastPrunesDeadSubscribers(t *testing.T) {
 	_ = deadServer.Close()
 
 	d := &Daemon{}
-	d.addSubscriber(deadServer)
-	d.addSubscriber(liveServer)
+	d.addSubscriber(deadServer, nil)
+	d.addSubscriber(liveServer, nil)
 
 	done := make(chan struct{})
 	go func() { defer close(done); d.broadcast(response{OK: true, Event: "gui-toggle"}) }()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/activation"
 	sddaemon "github.com/coreos/go-systemd/v22/daemon"
@@ -49,7 +50,7 @@ type Daemon struct {
 	state api.State
 
 	subMu       sync.Mutex
-	subscribers []net.Conn // long-lived connections subscribed to events
+	subscribers []subscriber // long-lived connections subscribed to events
 
 	buttonCh chan struct{}
 }
@@ -258,8 +259,8 @@ func (d *Daemon) broadcastLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			d.subMu.Lock()
-			for _, c := range d.subscribers {
-				_ = c.Close()
+			for _, s := range d.subscribers {
+				_ = s.conn.Close()
 			}
 			d.subscribers = nil
 			d.subMu.Unlock()
@@ -269,32 +270,95 @@ func (d *Daemon) broadcastLoop(ctx context.Context) {
 			// {"ok":false,...} on a perfectly good event, and any client that
 			// checks ok before dispatching — the documented contract — silently
 			// drops every button press.
-			d.broadcast(response{OK: true, Event: "gui-toggle"})
+			d.broadcast(response{OK: true, Event: api.EventGUIToggle})
 		}
 	}
 }
 
+// broadcastWriteTimeout bounds a single write to one subscriber.
+//
+// Broadcasts are emitted from handlers that hold hwMu, so an unbounded write to
+// a subscriber that has stopped reading — a hung GUI, a suspended process —
+// would block every hardware operation in the daemon behind a socket buffer.
+// A subscriber that cannot take a notification in this long is dropped. Declared
+// as a var so tests can shorten it.
+var broadcastWriteTimeout = 2 * time.Second
+
+// subscriber is one long-lived event connection and the events it asked for.
+type subscriber struct {
+	conn net.Conn
+	// events is the set the client subscribed to. Empty means every event: that
+	// is what a client sending no list gets, and it is what the daemon did for
+	// every subscriber before the filter existed.
+	events map[string]bool
+}
+
+// wants reports whether this subscriber asked for the named event.
+func (s subscriber) wants(event string) bool {
+	return len(s.events) == 0 || s.events[event]
+}
+
+// broadcast delivers an event to the subscribers that asked for it.
+//
+// The filter matters as soon as there is more than one event name: a client
+// that subscribed to "gui-toggle" and reasonably wrote `for range ch { toggle() }`
+// — the obvious loop when only one event existed — would otherwise toggle its
+// window on every power-source change.
 func (d *Daemon) broadcast(r response) {
 	data, _ := json.Marshal(r)
 	data = append(data, '\n')
 
 	d.subMu.Lock()
-	var alive []net.Conn
-	for _, c := range d.subscribers {
-		if _, err := c.Write(data); err == nil {
-			alive = append(alive, c)
+	alive := d.subscribers[:0:0]
+	for _, s := range d.subscribers {
+		if !s.wants(r.Event) {
+			alive = append(alive, s)
+			continue
+		}
+		_ = s.conn.SetWriteDeadline(time.Now().Add(broadcastWriteTimeout))
+		_, err := s.conn.Write(data)
+		_ = s.conn.SetWriteDeadline(time.Time{})
+		if err == nil {
+			alive = append(alive, s)
 		} else {
-			_ = c.Close()
+			_ = s.conn.Close()
 		}
 	}
 	d.subscribers = alive
 	d.subMu.Unlock()
 }
 
-func (d *Daemon) addSubscriber(conn net.Conn) {
+// addSubscriber registers a connection for the named events. An empty or nil
+// list subscribes to everything.
+func (d *Daemon) addSubscriber(conn net.Conn, events []string) {
+	set := make(map[string]bool, len(events))
+	for _, e := range events {
+		if e != "" {
+			set[e] = true
+		}
+	}
 	d.subMu.Lock()
-	d.subscribers = append(d.subscribers, conn)
+	d.subscribers = append(d.subscribers, subscriber{conn: conn, events: set})
 	d.subMu.Unlock()
+}
+
+// notifyStateChanged tells subscribers that profile or thermal state moved, so
+// anything displaying it can re-read. Callers pass the state they just saved
+// only to make the call sites read as "persist, then announce"; the event
+// carries no payload by design (see api/events.go).
+func (d *Daemon) notifyStateChanged() {
+	d.broadcast(response{OK: true, Event: api.EventStateChanged})
+}
+
+// saveAndNotify persists a state snapshot and announces the change. Every
+// handler that mutates profile or thermal state goes through this rather than
+// calling saveState directly, so a new handler cannot silently leave clients
+// showing stale values.
+func (d *Daemon) saveAndNotify(s api.State) {
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	d.notifyStateChanged()
 }
 
 // normalizeLightingState fills in any field left empty by a partial update,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -83,13 +83,54 @@ func Run(ctx context.Context, watchBtn bool) error {
 		}
 	}
 
+	// Resolve the power source before restoring anything, so a machine that was
+	// on AC when the daemon stopped and is on battery now lands on the battery
+	// profile directly. The watcher deliberately does not act on its first
+	// observation: the restore below already skips a redundant platform_profile
+	// write, and that write costs a WMI fan-controller reset (see the comment on
+	// the restore).
+	leftCustom := false
+	if onAC, acErr := cli.OnACPower(); acErr == nil {
+		if target := autoswitchTarget(d.state, onAC); target != "" {
+			source := "battery"
+			if onAC {
+				source = "AC"
+			}
+			slog.Info("autoswitch: selecting startup profile", "source", source, "profile", target)
+			leftCustom = d.state.InCustomProfile() && !d.state.IsCustomProfile(target)
+			d.state.Profile = target
+		}
+	}
+
+	// A daemon restart does not reset the fan controller or the Curve Optimizer
+	// — both are hardware state that outlives the process — so a custom profile
+	// that was in force is still in force now. If autoswitch has just moved us
+	// off it onto a firmware profile, release them, exactly as applyStockHW
+	// would. Without this the machine keeps running the old profile's fan curve
+	// and undervolt while the daemon reports a firmware profile, and the
+	// reconcile watcher stays inert because the profile is no longer custom.
+	if leftCustom {
+		if cli.SMUProbeUndervolt() {
+			if uvErr := cli.ResetCurveOptimizer(); uvErr != nil {
+				slog.Warn("failed to reset undervolt leaving the custom profile", "err", uvErr)
+			}
+		}
+		if fanErr := cli.ResetAllFanCurves(); fanErr != nil {
+			slog.Warn("failed to release fans leaving the custom profile", "err", fanErr)
+		}
+	}
+
 	// Restore stock profile if saved, but only if it differs from the
 	// kernel's current profile. Writing the same value to platform_profile
 	// still triggers a WMI call that resets the fan controller, briefly
 	// stopping fans — harmful on daemon restart where the profile hasn't
-	// changed. Skip "custom" — it's a virtual profile that the kernel
-	// rejects; custom fan curves and TDP are restored separately below.
-	if d.state.Profile != "" && d.state.Profile != "custom" {
+	// changed. Skip custom profiles — they are never written to
+	// platform_profile; their fan curves and TDP are restored separately below.
+	// Gated on IsStockProfile, not on "not custom": a state file naming a profile
+	// that is neither — one deleted by hand, or lost in a downgrade — would
+	// otherwise be written straight to platform_profile, where the kernel rejects
+	// it. Only a firmware profile name may ever reach that attribute.
+	if cli.IsStockProfile(d.state.Profile) {
 		current := ""
 		if data, readErr := os.ReadFile(cli.FindProfilePath()); readErr == nil {
 			current = strings.TrimSpace(string(data))
@@ -127,34 +168,17 @@ func Run(ctx context.Context, watchBtn bool) error {
 		}
 	}
 
-	// Restore fan curve + TDP if last profile was "custom".
-	if d.state.Profile == "custom" {
-		if fc := d.state.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
-			if fcErr := cli.SetBothFanCurves(fc.Points); fcErr != nil {
-				slog.Warn("failed to restore fan curve", "err", fcErr)
-			} else {
-				slog.Info("fan curve restored")
-			}
-		}
-		if t := d.state.TDP; t != nil {
-			// ApplyTDPSafely raises the fans to the 50% floor first when the
-			// sustained limit exceeds the safe max, and declines to apply the
-			// TDP at all if that fails — better to boot at the existing limits
-			// than above the safe sustained max with no thermal floor.
-			if tdpErr := cli.ApplyTDPSafely(*t); tdpErr != nil {
-				slog.Warn("failed to restore TDP", "err", tdpErr)
-			} else {
-				slog.Info("TDP restored", "pl1", t.PL1SPL, "pl2", t.PL2SPPT, "pl3", t.FPPT)
-			}
-		}
-		if uv := d.state.Undervolt; uv != nil && cli.SMUProbeUndervolt() {
-			if uvErr := cli.SetCurveOptimizer(uv.CPUCO); uvErr != nil {
-				slog.Warn("failed to restore undervolt", "err", uvErr)
-			} else {
-				d.state.Undervolt.Active = true
-				slog.Info("undervolt restored", "cpu", uv.CPUCO)
-			}
-		}
+	// Restore fan curve + TDP + undervolt if the last profile was a custom one.
+	// This goes through the same helper the socket command and the autoswitch
+	// watcher use, so startup cannot drift from them — in particular it clears
+	// the subsystems the profile does not set, which matters after a daemon
+	// restart where the previous profile's curve and offset are still live in
+	// hardware. ApplyTDPSafely still raises the fan floor before raising power
+	// and declines the TDP entirely if that write fails, so a machine can never
+	// come up above the safe sustained max without a floor.
+	if active, ok := d.state.ActiveCustomProfile(); ok && !active.Empty() {
+		slog.Info("restoring custom profile", "profile", active.Name)
+		d.applyCustomHW(active)
 	}
 
 	if watchBtn {
@@ -167,9 +191,12 @@ func Run(ctx context.Context, watchBtn bool) error {
 
 	go d.watchHotplug(ctx)
 
-	// State-driven, so it is a no-op on a machine that never uses the custom
+	// State-driven, so it is a no-op on a machine that never uses a custom
 	// profile; register it unconditionally.
 	go d.watchReconcile(ctx)
+
+	// Likewise inert until autoswitch is configured.
+	go d.watchPowerSource(ctx)
 
 	ln, err := d.getListener()
 	if err != nil {

--- a/internal/daemon/events_test.go
+++ b/internal/daemon/events_test.go
@@ -1,0 +1,146 @@
+package daemon
+
+// events_test.go — subscriber filtering and the write deadline that keeps a
+// wedged subscriber from stalling the daemon.
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dahui/z13ctl/api"
+)
+
+// readEvent reads one event line, or returns "" if none arrives quickly.
+func readEvent(t *testing.T, c net.Conn) string {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	line, err := bufio.NewReader(c).ReadBytes('\n')
+	if err != nil {
+		return ""
+	}
+	var got struct {
+		OK    bool   `json:"ok"`
+		Event string `json:"event"`
+	}
+	if err := json.Unmarshal(line, &got); err != nil {
+		t.Fatalf("event is not valid JSON: %v (%q)", err, line)
+	}
+	if !got.OK {
+		t.Errorf("event %q shipped ok=false; a client honouring the documented contract would drop it", got.Event)
+	}
+	return got.Event
+}
+
+// TestBroadcastRespectsTheSubscriptionFilter is the guard for a compatibility
+// trap. Before the filter existed the daemon wrote every event to every
+// subscriber, which was invisible while "gui-toggle" was the only event. A
+// client that subscribed to it and wrote the obvious loop —
+// `for range ch { toggleWindow() }`, reasonable when only one event exists —
+// would start toggling its window on every power-source change.
+func TestBroadcastRespectsTheSubscriptionFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		subscribe []string
+		emit      string
+		want      string
+	}{
+		{"subscribed to the emitted event", []string{api.EventGUIToggle}, api.EventGUIToggle, api.EventGUIToggle},
+		{"not subscribed to the emitted event", []string{api.EventGUIToggle}, api.EventPowerSource, ""},
+		{"subscribed to several", []string{api.EventGUIToggle, api.EventStateChanged}, api.EventStateChanged, api.EventStateChanged},
+		{"one of several not requested", []string{api.EventGUIToggle, api.EventStateChanged}, api.EventPowerSource, ""},
+		// An empty list keeps the pre-filter behaviour: everything.
+		{"empty list receives all", nil, api.EventPowerSource, api.EventPowerSource},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			defer func() { _ = client.Close() }()
+
+			d := &Daemon{}
+			d.addSubscriber(server, tt.subscribe)
+			go d.broadcast(response{OK: true, Event: tt.emit})
+
+			if got := readEvent(t, client); got != tt.want {
+				t.Errorf("subscribed to %v, emitted %q, received %q, want %q",
+					tt.subscribe, tt.emit, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBroadcastKeepsFilteredSubscribers covers a subtlety in the prune: a
+// subscriber that did not want this event must survive it. Dropping it would
+// silently unsubscribe every client the first time an event it did not ask for
+// was emitted.
+func TestBroadcastKeepsFilteredSubscribers(t *testing.T) {
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	d := &Daemon{}
+	d.addSubscriber(server, []string{api.EventGUIToggle})
+
+	go d.broadcast(response{OK: true, Event: api.EventPowerSource})
+	if got := readEvent(t, client); got != "" {
+		t.Fatalf("received %q, want nothing", got)
+	}
+
+	go d.broadcast(response{OK: true, Event: api.EventGUIToggle})
+	if got := readEvent(t, client); got != api.EventGUIToggle {
+		t.Errorf("received %q after a filtered event, want the subscriber to still be registered", got)
+	}
+}
+
+// TestBroadcastDropsAWedgedSubscriber covers the write deadline. Broadcasts are
+// emitted from handlers holding hwMu, so an unbounded write to a client that has
+// stopped reading would block every hardware operation in the daemon behind a
+// socket buffer.
+func TestBroadcastDropsAWedgedSubscriber(t *testing.T) {
+	prev := broadcastWriteTimeout
+	broadcastWriteTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { broadcastWriteTimeout = prev })
+
+	// net.Pipe is unbuffered and synchronous, so a client that never reads makes
+	// the write block — exactly the wedged-subscriber case.
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	d := &Daemon{}
+	d.addSubscriber(server, nil)
+
+	done := make(chan struct{})
+	go func() { defer close(done); d.broadcast(response{OK: true, Event: api.EventStateChanged}) }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("broadcast blocked on a subscriber that never reads; this would stall every hardware operation")
+	}
+
+	d.subMu.Lock()
+	n := len(d.subscribers)
+	d.subMu.Unlock()
+	if n != 0 {
+		t.Errorf("subscribers after a timed-out write = %d, want 0 (the wedged one should be dropped)", n)
+	}
+}
+
+// TestEventNamesAreStable pins the wire strings. They are part of the protocol,
+// so a rename is a breaking change for every client.
+func TestEventNamesAreStable(t *testing.T) {
+	want := map[string]string{
+		"gui-toggle":    api.EventGUIToggle,
+		"power-source":  api.EventPowerSource,
+		"state-changed": api.EventStateChanged,
+	}
+	for literal, constant := range want {
+		if literal != constant {
+			t.Errorf("event constant = %q, want the documented wire name %q", constant, literal)
+		}
+	}
+	if len(api.AllEvents) != len(want) {
+		t.Errorf("api.AllEvents has %d entries, want %d — a new event was not added to it", len(api.AllEvents), len(want))
+	}
+}

--- a/internal/daemon/powersource.go
+++ b/internal/daemon/powersource.go
@@ -75,9 +75,13 @@ type powerState struct {
 type powerAction struct {
 	Profile string
 	Reason  string
+	// SourceChanged reports a confirmed AC/battery transition, whether or not it
+	// calls for a profile change. Clients want the notification either way: an
+	// indicator is useful on a machine that never configures autoswitch.
+	SourceChanged bool
 }
 
-func (a powerAction) none() bool { return a.Profile == "" }
+func (a powerAction) none() bool { return a.Profile == "" && !a.SourceChanged }
 
 // powerTick decides whether a power-source observation calls for a profile
 // change. It is pure — no sysfs, no locks, no logging — because internal/cli's
@@ -136,24 +140,26 @@ func powerTick(prev powerState, obs powerObs) (powerState, powerAction) {
 	if confirmed {
 		st.onAC = source
 	}
+	// The transition itself is worth announcing even when nothing else follows.
+	act := powerAction{SourceChanged: confirmed}
 	if !confirmed && !justEnabled {
-		return st, powerAction{}
+		return st, act
 	}
 
 	if !enabled {
-		return st, powerAction{}
+		return st, act
 	}
 	target := obs.Auto.Target(source)
 	if target == "" {
 		// This side is unconfigured: hand it to the desktop.
-		return st, powerAction{}
+		return st, act
 	}
 	// Only the enable-time one-shot checks for equality. A confirmed source
 	// transition applies unconditionally: something else may have moved
 	// platform_profile behind our back, and skipping would leave the machine on
 	// the wrong profile with no way back until the next unplug.
 	if justEnabled && !confirmed && target == obs.Current {
-		return st, powerAction{}
+		return st, act
 	}
 
 	reason := "switched to battery"
@@ -163,7 +169,9 @@ func powerTick(prev powerState, obs powerObs) (powerState, powerAction) {
 	if justEnabled && !confirmed {
 		reason = "autoswitch enabled"
 	}
-	return st, powerAction{Profile: target, Reason: reason}
+	act.Profile = target
+	act.Reason = reason
+	return st, act
 }
 
 // watchPowerSource runs until ctx is done, applying the configured profile on
@@ -215,6 +223,13 @@ func (d *Daemon) powerSourceOnce(prev powerState) powerState {
 	source := "battery"
 	if obs.OnAC {
 		source = "AC"
+	}
+	if act.SourceChanged {
+		slog.Info("power source changed", "source", source)
+		d.broadcast(response{OK: true, Event: api.EventPowerSource})
+	}
+	if act.Profile == "" {
+		return st
 	}
 	slog.Info("autoswitch", "source", source, "profile", act.Profile, "reason", act.Reason)
 
@@ -339,9 +354,7 @@ func (d *Daemon) handleAutoswitch(req request) response {
 	d.state.Autoswitch = &api.AutoswitchState{Enabled: req.Enabled, AC: ac, Battery: battery}
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	slog.Info("autoswitch", "enabled", req.Enabled, "ac", ac, "battery", battery)
 	return response{OK: true}
 }

--- a/internal/daemon/powersource.go
+++ b/internal/daemon/powersource.go
@@ -1,0 +1,370 @@
+package daemon
+
+// powersource.go — applies a different profile on AC and on battery (issue #6).
+//
+// The watcher is EDGE-TRIGGERED on the mains adapter's "online" attribute, and
+// deliberately never reads or reasons about platform_profile. That is what
+// makes it safe to run alongside power-profiles-daemon: it reacts only to a
+// value that neither z13ctl nor PPD nor the desktop can write, so the feedback
+// loop that would produce a write-fight does not exist. A level-triggered
+// "keep my profile applied" watcher would both fight PPD over every AC
+// transition — the very thing reconcile.go was written to avoid — and make a
+// manual profile change impossible to hold.
+//
+// The consequence, which is the intended semantics: a profile chosen by hand
+// sticks until the power source actually changes. Between transitions z13ctl
+// yields. GNOME's "Automatic Power Saver", for instance, is a low-battery
+// trigger rather than an unplug trigger, and this watcher correctly ignores it.
+//
+// Detection has two triggers and one observation. UPower's OnBattery property
+// wakes the loop immediately where UPower is running; a 2 s poll is the backstop
+// that keeps this working in Steam Gaming Mode, on a bare session, or wherever
+// UPower is absent. Either way the answer comes from cli.OnACPower() reading
+// sysfs, so there is one code path to reason about and one to test.
+//
+// An observed edge is confirmed on the following observation before anything is
+// applied. That settle window buys two things: the apply lands after PPD's own
+// transition write, so a custom fan curve is not dropped in the gap before
+// reconcile.go notices, and a loose USB-C connector flapping "online" cannot
+// drive a full PPT + fan + SMU write per flap.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+const (
+	// powerPollInterval matches watchHotplug and watchReconcile. The read is one
+	// small sysfs file, so the cost is negligible.
+	powerPollInterval = 2 * time.Second
+
+	// powerQuietAfter is how many consecutive failed applies are logged before
+	// the watcher goes quiet, mirroring reconcileQuietAfter.
+	powerQuietAfter = 3
+)
+
+// powerObs is one observation of the power source and the configuration that
+// governs it.
+type powerObs struct {
+	OnAC    bool // mains adapter online
+	Known   bool // false when the source could not be determined
+	Auto    *api.AutoswitchState
+	Current string // the active profile, for the enable-time no-op check
+}
+
+// powerState is the latched watcher state carried between ticks.
+type powerState struct {
+	known    bool // an observation has been latched
+	onAC     bool // last latched source
+	enabled  bool // last latched autoswitch enablement
+	pending  bool // an edge is waiting for its confirming observation
+	pendAC   bool // the source that edge moved to
+	failures int
+	quiet    bool
+}
+
+// powerAction is what a tick decided to do. The zero value means "nothing".
+type powerAction struct {
+	Profile string
+	Reason  string
+}
+
+func (a powerAction) none() bool { return a.Profile == "" }
+
+// powerTick decides whether a power-source observation calls for a profile
+// change. It is pure — no sysfs, no locks, no logging — because internal/cli's
+// path vars are unexported, so a daemon test that reached the apply path would
+// rewrite the developer's actual machine.
+func powerTick(prev powerState, obs powerObs) (powerState, powerAction) {
+	st := prev
+
+	// An unreadable source is unknown, never "on battery". Latching it would
+	// have a machine with no mains device — a VM, a desktop, a driver not yet
+	// bound — apply the battery profile forever.
+	if !obs.Known {
+		return st, powerAction{}
+	}
+
+	enabled := obs.Auto != nil && obs.Auto.Enabled
+	source := obs.OnAC
+
+	// The first observation is latched without acting. Run() owns the startup
+	// apply, because it holds the same-value guard that keeps a redundant
+	// platform_profile write — and the WMI fan-controller reset that comes with
+	// it — out of every daemon restart.
+	//
+	// Enablement is latched as false regardless of what was observed, so the
+	// next tick sees an enable edge and re-checks. Latching the observed value
+	// instead swallowed any autoswitch configured in the two seconds before the
+	// first tick: the edge had already passed, and nothing applied until a real
+	// plug or unplug. The re-check is not a duplicate of Run()'s apply, because
+	// the enable-time path skips when the target is already active — which it is
+	// whenever Run() has just applied it.
+	if !st.known {
+		st.known = true
+		st.onAC = source
+		st.enabled = false
+		return st, powerAction{}
+	}
+
+	sourceChanged := source != st.onAC
+	// Enabling autoswitch while running is a deliberate one-shot: apply the
+	// target for the source we are already on.
+	justEnabled := enabled && !st.enabled
+
+	st.enabled = enabled
+
+	// Confirm a source change on the next observation before acting on it.
+	if sourceChanged {
+		if !st.pending || st.pendAC != source {
+			st.pending = true
+			st.pendAC = source
+			return st, powerAction{}
+		}
+	}
+	confirmed := sourceChanged && st.pending && st.pendAC == source
+	st.pending = false
+
+	if confirmed {
+		st.onAC = source
+	}
+	if !confirmed && !justEnabled {
+		return st, powerAction{}
+	}
+
+	if !enabled {
+		return st, powerAction{}
+	}
+	target := obs.Auto.Target(source)
+	if target == "" {
+		// This side is unconfigured: hand it to the desktop.
+		return st, powerAction{}
+	}
+	// Only the enable-time one-shot checks for equality. A confirmed source
+	// transition applies unconditionally: something else may have moved
+	// platform_profile behind our back, and skipping would leave the machine on
+	// the wrong profile with no way back until the next unplug.
+	if justEnabled && !confirmed && target == obs.Current {
+		return st, powerAction{}
+	}
+
+	reason := "switched to battery"
+	if source {
+		reason = "switched to AC"
+	}
+	if justEnabled && !confirmed {
+		reason = "autoswitch enabled"
+	}
+	return st, powerAction{Profile: target, Reason: reason}
+}
+
+// watchPowerSource runs until ctx is done, applying the configured profile on
+// each confirmed AC/battery transition.
+func (d *Daemon) watchPowerSource(ctx context.Context) {
+	nudge := make(chan struct{}, 4)
+	go watchUPower(ctx, nudge)
+
+	var st powerState
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-nudge:
+			// UPower says something moved. Give the kernel and PPD a moment to
+			// settle before the confirming observation reads sysfs.
+		case <-time.After(powerPollInterval):
+		}
+		st = d.powerSourceOnce(st)
+	}
+}
+
+// powerSourceOnce performs one observe-decide-apply cycle and returns the new
+// latched state. It is the only part of the watcher that touches hardware.
+func (d *Daemon) powerSourceOnce(prev powerState) powerState {
+	// hwMu before d.mu, always: applyProfileLocked writes the same sysfs
+	// attributes the socket handlers do.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	obs := powerObs{Current: d.state.Profile}
+	if a := d.state.Autoswitch; a != nil {
+		auto := *a
+		obs.Auto = &auto
+	}
+	d.mu.Unlock()
+
+	if onAC, err := cli.OnACPower(); err == nil {
+		obs.OnAC = onAC
+		obs.Known = true
+	}
+
+	st, act := powerTick(prev, obs)
+	if act.none() {
+		return st
+	}
+
+	source := "battery"
+	if obs.OnAC {
+		source = "AC"
+	}
+	slog.Info("autoswitch", "source", source, "profile", act.Profile, "reason", act.Reason)
+
+	if err := d.applyProfileLocked(act.Profile); err != nil {
+		st.failures++
+		if !st.quiet {
+			slog.Warn("autoswitch failed to apply profile", "profile", act.Profile, "err", err)
+		}
+		if st.failures >= powerQuietAfter && !st.quiet {
+			slog.Warn("autoswitch keeps failing; further attempts will not be logged", "attempts", st.failures)
+			st.quiet = true
+		}
+		// The source really did change, so the latch stands: retrying every
+		// tick against an unwritable sysfs would be a write storm, and
+		// reconcile.go independently defends whatever custom settings are live.
+		return st
+	}
+	st.failures = 0
+	st.quiet = false
+	return st
+}
+
+// watchUPower nudges the poll loop whenever UPower reports a change to
+// OnBattery. It fails soft in exactly the way watchResume does: log once and
+// return, leaving the 2 s poll as the only trigger. Nothing depends on it — it
+// only shortens the latency of a transition from up to 4 s to about 2 s.
+func watchUPower(ctx context.Context, nudge chan<- struct{}) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		slog.Debug("no system DBus for the power source watcher; polling only", "err", err)
+		return
+	}
+	if err := conn.AddMatchSignal(
+		dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
+		dbus.WithMatchMember("PropertiesChanged"),
+		dbus.WithMatchObjectPath("/org/freedesktop/UPower"),
+	); err != nil {
+		slog.Debug("cannot watch UPower for power source changes; polling only", "err", err)
+		return
+	}
+	ch := make(chan *dbus.Signal, 4)
+	conn.Signal(ch)
+	slog.Info("power source watcher started (UPower signals plus sysfs polling)")
+
+	for {
+		select {
+		case <-ctx.Done():
+			conn.RemoveSignal(ch)
+			return
+		case sig := <-ch:
+			if sig == nil || len(sig.Body) < 2 {
+				continue
+			}
+			iface, _ := sig.Body[0].(string)
+			if iface != "org.freedesktop.UPower" {
+				continue
+			}
+			changed, ok := sig.Body[1].(map[string]dbus.Variant)
+			if !ok {
+				continue
+			}
+			if _, ok := changed["OnBattery"]; !ok {
+				continue
+			}
+			select {
+			case nudge <- struct{}{}:
+			default: // a nudge is already queued; one is as good as many
+			}
+		}
+	}
+}
+
+// autoswitchTarget returns the profile the current power source calls for, or
+// "" when autoswitch is off, unconfigured for that source, or already active.
+//
+// Run() uses this to resolve the startup profile before its restore blocks, so
+// a machine that was on AC when the daemon stopped and is on battery now lands
+// on the battery profile directly instead of applying the AC profile and
+// switching moments later.
+func autoswitchTarget(s api.State, onAC bool) string {
+	target := s.Autoswitch.Target(onAC)
+	if target == "" || target == s.Profile {
+		return ""
+	}
+	if cli.IsStockProfile(target) {
+		return target
+	}
+	if !s.IsCustomProfile(target) {
+		return ""
+	}
+	// An empty custom profile has nothing to apply. applyProfileLocked refuses
+	// it, so returning it here would have startup claim a profile the watcher
+	// would decline to select — and leave hardware describing the old one.
+	if s.CustomProfiles[target].Empty() {
+		return ""
+	}
+	return target
+}
+
+func (d *Daemon) handleAutoswitch(req request) response {
+	ac := strings.ToLower(strings.TrimSpace(req.AC))
+	battery := strings.ToLower(strings.TrimSpace(req.Battery))
+
+	d.mu.Lock()
+	// Only when enabling. Turning autoswitch off must always be possible, even
+	// if a target has gone stale — refusing there would leave it enabled with no
+	// way back short of editing the state file.
+	//
+	// Ordered, not a map range: with both sides wrong, a random iteration order
+	// would report a different one each run.
+	if req.Enabled {
+		for _, side := range []struct{ slot, name string }{{"ac", ac}, {"battery", battery}} {
+			if side.name == "" {
+				continue
+			}
+			if !cli.IsStockProfile(side.name) && !d.state.IsCustomProfile(side.name) {
+				d.mu.Unlock()
+				return response{OK: false, Error: "autoswitch: unknown " + side.slot + " profile " + side.name}
+			}
+		}
+	}
+	d.state.Autoswitch = &api.AutoswitchState{Enabled: req.Enabled, AC: ac, Battery: battery}
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	slog.Info("autoswitch", "enabled", req.Enabled, "ac", ac, "battery", battery)
+	return response{OK: true}
+}
+
+func (d *Daemon) handleAutoswitchGet() response {
+	d.mu.Lock()
+	a := api.AutoswitchState{}
+	if d.state.Autoswitch != nil {
+		a = *d.state.Autoswitch
+	}
+	d.mu.Unlock()
+
+	// Include the live source so a client can render "active on battery"
+	// without a second round trip.
+	out := struct {
+		api.AutoswitchState
+		OnAC  bool `json:"on_ac"`
+		Known bool `json:"source_known"`
+	}{AutoswitchState: a}
+	if onAC, err := cli.OnACPower(); err == nil {
+		out.OnAC = onAC
+		out.Known = true
+	}
+	data, _ := json.Marshal(out)
+	return response{OK: true, Value: string(data)}
+}

--- a/internal/daemon/powersource_test.go
+++ b/internal/daemon/powersource_test.go
@@ -1,0 +1,312 @@
+package daemon
+
+// powersource_test.go — decision coverage for the AC/battery autoswitch watcher.
+//
+// Every case goes through the pure powerTick. That is deliberate and not
+// negotiable: internal/cli's sysfs path vars are unexported, so a daemon test
+// that reached applyProfileLocked would rewrite the developer's actual power
+// limits, fan mode, and Curve Optimizer offset.
+
+import (
+	"testing"
+
+	"github.com/dahui/z13ctl/api"
+)
+
+func auto(enabled bool, ac, battery string) *api.AutoswitchState {
+	return &api.AutoswitchState{Enabled: enabled, AC: ac, Battery: battery}
+}
+
+// latched returns the state a watcher would hold after settling on a source
+// with autoswitch in the given enablement.
+func latched(onAC, enabled bool) powerState {
+	return powerState{known: true, onAC: onAC, enabled: enabled}
+}
+
+func TestPowerTick(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+
+	tests := []struct {
+		name string
+		prev powerState
+		obs  powerObs
+		want string // profile the tick should apply; "" for none
+	}{
+		{
+			name: "unknown source never acts",
+			prev: latched(true, true),
+			obs:  powerObs{OnAC: false, Known: false, Auto: cfg, Current: "balanced"},
+		},
+		{
+			name: "first observation latches without acting",
+			obs:  powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"},
+		},
+		{
+			name: "no change, nothing to do",
+			prev: latched(true, true),
+			obs:  powerObs{OnAC: true, Known: true, Auto: cfg, Current: "balanced"},
+		},
+		{
+			name: "an unconfirmed transition waits for the settle window",
+			prev: latched(true, true),
+			obs:  powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"},
+		},
+		{
+			name: "disabled autoswitch tracks the source but does not act",
+			prev: powerState{known: true, onAC: true, enabled: false, pending: true, pendAC: false},
+			obs:  powerObs{OnAC: false, Known: true, Auto: auto(false, "balanced", "battery-uv"), Current: "balanced"},
+		},
+		{
+			name: "no configuration at all",
+			prev: latched(true, false),
+			obs:  powerObs{OnAC: false, Known: true, Auto: nil, Current: "balanced"},
+		},
+		{
+			name: "an unconfigured side is left to the desktop",
+			prev: powerState{known: true, onAC: true, enabled: true, pending: true, pendAC: false},
+			obs:  powerObs{OnAC: false, Known: true, Auto: auto(true, "balanced", ""), Current: "balanced"},
+		},
+		{
+			name: "confirmed unplug applies the battery profile",
+			prev: powerState{known: true, onAC: true, enabled: true, pending: true, pendAC: false},
+			obs:  powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"},
+			want: "battery-uv",
+		},
+		{
+			name: "confirmed replug applies the AC profile",
+			prev: powerState{known: true, onAC: false, enabled: true, pending: true, pendAC: true},
+			obs:  powerObs{OnAC: true, Known: true, Auto: cfg, Current: "battery-uv"},
+			want: "balanced",
+		},
+		{
+			// Something else — PPD, Fn+F5, asusctl — may have moved the profile
+			// between transitions. Skipping on equality would leave the machine
+			// on the wrong profile until the next unplug.
+			name: "a confirmed transition applies even when the target is already active",
+			prev: powerState{known: true, onAC: false, enabled: true, pending: true, pendAC: true},
+			obs:  powerObs{OnAC: true, Known: true, Auto: cfg, Current: "balanced"},
+			want: "balanced",
+		},
+		{
+			name: "enabling while running applies the current source's target",
+			prev: latched(false, false),
+			obs:  powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"},
+			want: "battery-uv",
+		},
+		{
+			name: "enabling is a no-op when the target is already active",
+			prev: latched(false, false),
+			obs:  powerObs{OnAC: false, Known: true, Auto: cfg, Current: "battery-uv"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, act := powerTick(tt.prev, tt.obs)
+			if act.Profile != tt.want {
+				t.Errorf("powerTick() applied %q, want %q", act.Profile, tt.want)
+			}
+			if tt.want != "" && act.Reason == "" {
+				t.Error("an action carries no reason, so the journal line would say nothing")
+			}
+		})
+	}
+}
+
+// TestPowerTickAppliesAutoswitchConfiguredBeforeTheFirstTick covers a window
+// the watcher used to swallow: autoswitch configured in the two seconds between
+// daemon start and the first observation. Latching the observed enablement meant
+// the enable edge had already passed, so nothing applied until a real plug or
+// unplug.
+func TestPowerTickAppliesAutoswitchConfiguredBeforeTheFirstTick(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+	obs := powerObs{OnAC: false, Known: true, Auto: cfg, Current: "quiet"}
+
+	st, act := powerTick(powerState{}, obs)
+	if !act.none() {
+		t.Fatalf("acted on the first observation: %+v — Run() owns the startup apply", act)
+	}
+
+	_, act = powerTick(st, obs)
+	if act.Profile != "battery-uv" {
+		t.Errorf("second tick applied %q, want \"battery-uv\"", act.Profile)
+	}
+}
+
+// TestPowerTickDoesNotRepeatTheStartupApply is the other half: when Run() has
+// already put the target in force, the re-check must be a no-op rather than a
+// second apply.
+func TestPowerTickDoesNotRepeatTheStartupApply(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+	obs := powerObs{OnAC: false, Known: true, Auto: cfg, Current: "battery-uv"}
+
+	st, _ := powerTick(powerState{}, obs)
+	if _, act := powerTick(st, obs); !act.none() {
+		t.Errorf("re-applied a profile that is already active: %+v", act)
+	}
+}
+
+// TestPowerTickLatchesThroughADisabledTransition keeps the source latch honest
+// while autoswitch is off, so re-enabling later does not read as a transition
+// that already happened.
+func TestPowerTickLatchesThroughADisabledTransition(t *testing.T) {
+	off := auto(false, "balanced", "battery-uv")
+	st := latched(true, false)
+
+	st, act := powerTick(st, powerObs{OnAC: false, Known: true, Auto: off, Current: "balanced"})
+	if !act.none() {
+		t.Fatalf("acted while disabled: %+v", act)
+	}
+	st, act = powerTick(st, powerObs{OnAC: false, Known: true, Auto: off, Current: "balanced"})
+	if !act.none() {
+		t.Fatalf("acted while disabled: %+v", act)
+	}
+	if st.onAC {
+		t.Fatal("the source latch did not follow the transition while disabled")
+	}
+
+	// Re-enabling now is a one-shot for the source we are actually on.
+	if _, act = powerTick(st, powerObs{OnAC: false, Known: true, Auto: auto(true, "balanced", "battery-uv"), Current: "balanced"}); act.Profile != "battery-uv" {
+		t.Errorf("enabling applied %q, want \"battery-uv\"", act.Profile)
+	}
+}
+
+// TestPowerTickSettleWindow walks a real transition tick by tick. The first
+// observation of a new source only arms it; the second applies. That window is
+// what lets power-profiles-daemon's own transition write land first, so a
+// custom fan curve is not dropped in the gap before reconcile.go notices.
+func TestPowerTickSettleWindow(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+	st := latched(true, true)
+
+	st, act := powerTick(st, powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"})
+	if !act.none() {
+		t.Fatalf("acted on the first observation of a new source: %+v", act)
+	}
+	if !st.pending {
+		t.Fatal("the transition was not armed, so the confirming tick has nothing to confirm")
+	}
+
+	st, act = powerTick(st, powerObs{OnAC: false, Known: true, Auto: cfg, Current: "balanced"})
+	if act.Profile != "battery-uv" {
+		t.Fatalf("the confirming tick applied %q, want \"battery-uv\"", act.Profile)
+	}
+	if st.onAC {
+		t.Error("the new source was not latched, so the next tick would apply again")
+	}
+
+	// Settled: no further action without another transition.
+	_, act = powerTick(st, powerObs{OnAC: false, Known: true, Auto: cfg, Current: "battery-uv"})
+	if !act.none() {
+		t.Errorf("acted again with no transition: %+v — this is the level-trigger that would fight PPD", act)
+	}
+}
+
+// TestPowerTickIgnoresAFlappingCharger is the other half of the settle window.
+// A loose USB-C connector that bounces "online" between observations must not
+// drive a full PPT + fan + SMU write per bounce.
+func TestPowerTickIgnoresAFlappingCharger(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+	st := latched(true, true)
+
+	for i, onAC := range []bool{false, true, false, true} {
+		var act powerAction
+		st, act = powerTick(st, powerObs{OnAC: onAC, Known: true, Auto: cfg, Current: "balanced"})
+		if !act.none() {
+			t.Fatalf("flap %d (onAC=%v) triggered an apply: %+v", i, onAC, act)
+		}
+	}
+	if !st.onAC {
+		t.Error("the latched source moved during a flap, so the machine's real source was lost")
+	}
+}
+
+// TestPowerTickNeverInfersBatteryFromAnUnreadableSource pins the contract that
+// keeps a VM or a desktop — anything with no mains device — from having the
+// battery profile applied to it forever.
+func TestPowerTickNeverInfersBatteryFromAnUnreadableSource(t *testing.T) {
+	cfg := auto(true, "balanced", "battery-uv")
+	var st powerState
+	for range 5 {
+		var act powerAction
+		st, act = powerTick(st, powerObs{Known: false, Auto: cfg, Current: "balanced"})
+		if !act.none() {
+			t.Fatalf("acted on an unknown source: %+v", act)
+		}
+	}
+	if st.known {
+		t.Error("an unknown source was latched, so a later real reading would look like no change")
+	}
+}
+
+func TestAutoswitchTarget(t *testing.T) {
+	profiles := map[string]api.CustomProfile{
+		"battery-uv": {Name: "battery-uv", TDP: &api.TDPState{PL1SPL: 35}},
+		"blank":      {Name: "blank"}, // created but never populated
+	}
+
+	tests := []struct {
+		name string
+		s    api.State
+		onAC bool
+		want string
+	}{
+		{
+			name: "no configuration",
+			s:    api.State{Profile: "balanced"},
+			onAC: true,
+		},
+		{
+			name: "disabled",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(false, "quiet", "battery-uv"), CustomProfiles: profiles},
+		},
+		{
+			name: "battery target",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(true, "quiet", "battery-uv"), CustomProfiles: profiles},
+			want: "battery-uv",
+		},
+		{
+			name: "AC target",
+			s:    api.State{Profile: "battery-uv", Autoswitch: auto(true, "quiet", "battery-uv"), CustomProfiles: profiles},
+			onAC: true,
+			want: "quiet",
+		},
+		{
+			name: "already active, nothing to do at startup",
+			s:    api.State{Profile: "battery-uv", Autoswitch: auto(true, "quiet", "battery-uv"), CustomProfiles: profiles},
+			want: "",
+		},
+		{
+			name: "unconfigured side",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(true, "", "battery-uv"), CustomProfiles: profiles},
+			onAC: true,
+		},
+		{
+			// A profile deleted from a hand-edited state file, or lost in a
+			// downgrade. Returning it would have Run() set state.Profile to a
+			// name that does not resolve.
+			name: "target that no longer exists",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(true, "quiet", "deleted"), CustomProfiles: profiles},
+		},
+		{
+			// applyProfileLocked refuses an empty profile, so returning it here
+			// would have startup claim a profile the watcher declines to select,
+			// leaving hardware describing the previous one.
+			name: "target exists but holds no settings",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(true, "quiet", "blank"), CustomProfiles: profiles},
+		},
+		{
+			name: "custom targets that do hold settings are still selected",
+			s:    api.State{Profile: "balanced", Autoswitch: auto(true, "quiet", "battery-uv"), CustomProfiles: profiles},
+			want: "battery-uv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := autoswitchTarget(tt.s, tt.onAC); got != tt.want {
+				t.Errorf("autoswitchTarget(onAC=%v) = %q, want %q", tt.onAC, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/powersource_test.go
+++ b/internal/daemon/powersource_test.go
@@ -154,12 +154,17 @@ func TestPowerTickLatchesThroughADisabledTransition(t *testing.T) {
 	st := latched(true, false)
 
 	st, act := powerTick(st, powerObs{OnAC: false, Known: true, Auto: off, Current: "balanced"})
-	if !act.none() {
-		t.Fatalf("acted while disabled: %+v", act)
+	if act.Profile != "" {
+		t.Fatalf("applied a profile while disabled: %+v", act)
 	}
 	st, act = powerTick(st, powerObs{OnAC: false, Known: true, Auto: off, Current: "balanced"})
-	if !act.none() {
-		t.Fatalf("acted while disabled: %+v", act)
+	if act.Profile != "" {
+		t.Fatalf("applied a profile while disabled: %+v", act)
+	}
+	// The transition is still announced: an AC/battery indicator is useful on a
+	// machine that never configures autoswitch, which is most of them.
+	if !act.SourceChanged {
+		t.Error("a confirmed transition was not announced while autoswitch was disabled")
 	}
 	if st.onAC {
 		t.Fatal("the source latch did not follow the transition while disabled")

--- a/internal/daemon/profile.go
+++ b/internal/daemon/profile.go
@@ -1,0 +1,461 @@
+package daemon
+
+// profile.go — applying a profile, and the CRUD around named custom profiles.
+//
+// A profile is either one of the three firmware profiles written to
+// platform_profile, or a custom profile: a named set of fan curve, TDP and
+// Curve Optimizer settings that z13ctl applies itself and that never touches
+// platform_profile. state.CustomProfiles is the source of truth for the latter;
+// api.State's FanCurve/TDP/Undervolt fields are only a projection of the active
+// one, filled in at the serialization boundaries (see withLegacyProjection).
+//
+// The firmware profile names are reserved end to end — validation refuses them,
+// loadState drops a map entry carrying one, api.State.IsCustomProfile answers
+// false for one, and applyProfileLocked tests for a stock name before it ever
+// consults the map. Selecting "balanced" therefore always reaches the firmware
+// profile, with no way for a custom profile to shadow it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+// applyProfileLocked applies a profile — firmware or custom — to hardware and
+// updates daemon state to match. It is the single implementation behind both
+// the "profile" socket command and the AC/battery autoswitch watcher.
+//
+// The caller must hold d.hwMu and must NOT hold d.mu. This function takes d.mu
+// itself, and the lock order in this package is hwMu then d.mu, always. For the
+// same reason nothing reached from here may call d.effectiveProfile(), which
+// takes d.mu.
+func (d *Daemon) applyProfileLocked(profile string) error {
+	// Stock first, before the map is consulted at all. This is the last of the
+	// four layers that keep a custom profile from shadowing a firmware one, and
+	// the only one that still holds if a hand-edited state file gets past the
+	// other three.
+	if cli.IsStockProfile(profile) {
+		return d.applyStockHW(profile)
+	}
+
+	d.mu.Lock()
+	if !d.state.IsCustomProfile(profile) {
+		d.mu.Unlock()
+		return fmt.Errorf("unknown profile %q: not a firmware profile and not saved", profile)
+	}
+	p := d.state.CustomProfiles[profile]
+	p.Name = profile
+	if p.Empty() {
+		d.mu.Unlock()
+		return fmt.Errorf("profile %q has no settings saved; set a fan curve, TDP, or undervolt first", profile)
+	}
+	// Set the active profile before the hardware work, not after. That is what
+	// makes the reconcile watcher start defending the fans *during* the apply,
+	// and it lets a half-failed apply self-heal on the next reconcile tick
+	// rather than leaving the daemon claiming a stock profile while a custom
+	// curve is live. Deciding custom-ness and snapshotting in one critical
+	// section also closes the window where a concurrent profile-delete could
+	// remove the entry between the two.
+	d.state.Profile = profile
+	p = cloneCustomProfile(p)
+	d.mu.Unlock()
+
+	d.applyCustomHW(p)
+	return nil
+}
+
+// applyCustomHW puts hardware into the state a custom profile describes.
+//
+// A subsystem the profile leaves nil is *cleared*, not left alone. That is what
+// makes switching between two custom profiles predictable: without it, going
+// from a profile with a 90 W limit and a -25 offset to one that sets neither
+// leaves both in force while the daemon reports the second profile. Selecting
+// A then B then A again would not give the same machine as selecting A.
+//
+// Ordering is the fail-closed part and is not free to rearrange:
+//
+//   - The profile's own curve goes on *before* its TDP, so ApplyTDPSafely's
+//     high-TDP floor is written last and wins if the two disagree.
+//   - Clearing the TDP hands the limits back to the firmware profile underneath,
+//     which lowers power before the fans are touched.
+//   - The fans are released only when no high sustained limit is in force. A
+//     profile with a high TDP and no curve of its own keeps the floor
+//     ApplyTDPSafely just wrote.
+//
+// Individual failures are logged rather than returned: a profile that only
+// partly applies is still the profile the user asked for, and the reconcile
+// watcher keeps trying on the parts it owns.
+func (d *Daemon) applyCustomHW(p api.CustomProfile) {
+	hasCurve := p.FanCurve != nil && p.FanCurve.Mode == 1 && len(p.FanCurve.Points) == 8
+	if hasCurve {
+		if err := cli.SetBothFanCurves(p.FanCurve.Points); err != nil {
+			slog.Warn("failed to apply fan curve", "profile", p.Name, "err", err)
+		}
+	}
+
+	highTDP := false
+	if t := p.TDP; t != nil {
+		if err := cli.ApplyTDPSafely(*t); err != nil {
+			slog.Warn("failed to apply TDP", "profile", p.Name, "err", err)
+		} else {
+			highTDP = t.PL1SPL > cli.TDPMaxSafe
+		}
+	} else {
+		// Not controlled here, so hand the limits back to the firmware profile
+		// underneath rather than leaving the previous profile's watts in force.
+		restoreStockPPT(readProfileFromSysfs())
+	}
+
+	if !hasCurve && !highTDP {
+		if err := cli.ResetAllFanCurves(); err != nil {
+			slog.Warn("failed to release fans to firmware auto", "profile", p.Name, "err", err)
+		}
+	}
+
+	uvActive := false
+	if cli.SMUProbeUndervolt() {
+		if uv := p.Undervolt; uv != nil {
+			if err := cli.SetCurveOptimizer(uv.CPUCO); err != nil {
+				slog.Warn("failed to apply undervolt", "profile", p.Name, "err", err)
+			} else {
+				uvActive = true
+			}
+		} else if err := cli.ResetCurveOptimizer(); err != nil {
+			slog.Warn("failed to reset undervolt", "profile", p.Name, "err", err)
+		}
+	}
+
+	d.mu.Lock()
+	// Active describes hardware, so it is set here and nowhere else — and only
+	// when the SMU write actually succeeded.
+	setUndervoltActive(d.state, false)
+	if uvActive {
+		if cur, ok := d.state.CustomProfiles[p.Name]; ok && cur.Undervolt != nil {
+			cur.Undervolt.Active = true
+		}
+	}
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+}
+
+// applyStockHW switches to a firmware profile.
+//
+// The order below is deliberate and load-bearing. Reset the undervolt first
+// (every route to a stock profile must clear it, or a custom setting leaks into
+// a stock profile). Write platform_profile next; a failure there aborts with
+// state untouched. Restore that profile's stock PPT — the firmware does not
+// re-apply per-profile limits on a profile change, so without this a custom TDP
+// persists across the switch. Release the fans to firmware auto *last*, so they
+// are never dropped to auto while a high custom TDP is still in force.
+func (d *Daemon) applyStockHW(profile string) error {
+	if cli.SMUProbeUndervolt() {
+		if err := cli.ResetCurveOptimizer(); err != nil {
+			slog.Warn("failed to reset undervolt", "err", err)
+		}
+	}
+	if err := cli.SetProfile(profile); err != nil {
+		return err
+	}
+	restoreStockPPT(profile)
+	if err := cli.ResetAllFanCurves(); err != nil {
+		slog.Warn("failed to reset fan curves to auto", "err", err)
+	}
+
+	d.mu.Lock()
+	d.state.Profile = profile
+	setUndervoltActive(d.state, false)
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	return nil
+}
+
+// setUndervoltActive stamps the Active flag across every saved profile. Curve
+// Optimizer is global hardware state, so at most one profile's offset can be
+// applied; clearing all of them is both correct and immune to the active
+// profile having changed underneath. Caller must hold d.mu.
+func setUndervoltActive(s api.State, active bool) {
+	for _, p := range s.CustomProfiles {
+		if p.Undervolt != nil {
+			p.Undervolt.Active = active
+		}
+	}
+}
+
+// editTarget names the custom profile a fancurve/tdp/undervolt command edits,
+// and says whether that profile is the active one — which is what decides
+// whether the command also writes hardware.
+type editTarget struct {
+	Name    string
+	Live    bool
+	Profile api.CustomProfile // the profile as it stands before the edit
+}
+
+// resolveEditTarget works out which profile a setting command edits.
+//
+// An empty name means the active profile, creating and activating the default
+// "custom" profile when a firmware profile is active — which is exactly how
+// z13ctl behaved before named profiles existed, so no existing invocation
+// changes meaning. A name selects that profile without activating it, which is
+// what makes it possible to build the battery profile while running on AC.
+//
+// Caller must hold d.mu.
+func (d *Daemon) resolveEditTargetLocked(name string) (editTarget, error) {
+	// A lookup, so fold case: profile names are always stored lowercase.
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		// The profile currently running. When a firmware profile is active that
+		// is the default custom profile, created and activated by this very
+		// edit, so the target is live either way.
+		name = d.state.Profile
+		if !d.state.IsCustomProfile(name) {
+			name = api.DefaultCustomProfile
+		}
+		return d.editTargetLocked(name, true), nil
+	}
+	if cli.IsStockProfile(name) {
+		return editTarget{}, fmt.Errorf("%q is a firmware profile and has no custom settings to edit", name)
+	}
+	if name != api.DefaultCustomProfile && !d.state.IsCustomProfile(name) {
+		return editTarget{}, fmt.Errorf("unknown profile %q; create it with 'z13ctl profile --create %s'", name, name)
+	}
+	return d.editTargetLocked(name, name == d.state.Profile), nil
+}
+
+// editTargetLocked builds the target for a known profile name. Caller must hold
+// d.mu.
+func (d *Daemon) editTargetLocked(name string, live bool) editTarget {
+	p := d.state.CustomProfiles[name]
+	p.Name = name
+	return editTarget{Name: name, Live: live, Profile: cloneCustomProfile(p)}
+}
+
+// commitEditLocked writes an edited profile back and, when it is the live one,
+// makes it the active profile. Caller must hold d.mu; returns the snapshot to
+// hand to saveState after unlocking.
+func (d *Daemon) commitEditLocked(t editTarget, p api.CustomProfile) api.State {
+	p.Name = t.Name
+	if d.state.CustomProfiles == nil {
+		d.state.CustomProfiles = make(map[string]api.CustomProfile, 1)
+	}
+	d.state.CustomProfiles[t.Name] = p
+	if t.Live {
+		d.state.Profile = t.Name
+	}
+	return cloneState(d.state)
+}
+
+// activeTDPFor returns the sustained limit a curve edit must clear.
+//
+// For the live profile that is whatever hardware reports, which is ground truth
+// and can disagree with saved state. For any other profile hardware says
+// nothing, so the limit to check against is the one stored in that same
+// profile — which is what stops a profile being saved in a state that would be
+// unsafe the moment it is activated.
+func (d *Daemon) floorLimitFor(t editTarget) int {
+	if t.Live {
+		tdp, err := cli.ReadEffectivePPT(t.Name)
+		if err != nil {
+			// A PPT read failure is deliberately not a refusal: the guard is
+			// best-effort and must not make fan control unavailable.
+			return 0
+		}
+		return tdp.PL1SPL
+	}
+	if t.Profile.TDP == nil {
+		return 0
+	}
+	return t.Profile.TDP.PL1SPL
+}
+
+func (d *Daemon) handleProfile(req request) response {
+	if req.Set == "" {
+		return response{OK: false, Error: "profile requires a set field"}
+	}
+	profile := strings.ToLower(req.Set)
+
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	if err := d.applyProfileLocked(profile); err != nil {
+		return response{OK: false, Error: "profile: " + err.Error()}
+	}
+	slog.Info("profile", "set", profile)
+	return response{OK: true}
+}
+
+// handleProfileCreate adds an empty custom profile without activating it.
+//
+// The name is validated as typed, not case-folded first: silently creating
+// "gaming" from "Gaming" leaves the user looking for a profile under a name
+// that is not there. Lookups are lenient in the other direction — selecting or
+// editing a profile does fold case.
+func (d *Daemon) handleProfileCreate(req request) response {
+	name := strings.TrimSpace(req.Set)
+	if err := cli.ValidateProfileName(name); err != nil {
+		return response{OK: false, Error: "profile-create: " + err.Error()}
+	}
+	// hwMu even though this writes no hardware: the fancurve/tdp/undervolt
+	// handlers resolve a target under d.mu, release it for the hardware write,
+	// and commit the profile back under d.mu again. Mutating the profile map
+	// inside that window would be silently undone by the commit — or, for a
+	// delete, undone by resurrecting the profile. hwMu is what makes the whole
+	// resolve-write-commit span exclusive.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	if _, exists := d.state.CustomProfiles[name]; exists {
+		d.mu.Unlock()
+		return response{OK: false, Error: "profile-create: profile " + name + " already exists"}
+	}
+	if d.state.CustomProfiles == nil {
+		d.state.CustomProfiles = make(map[string]api.CustomProfile, 1)
+	}
+	d.state.CustomProfiles[name] = api.CustomProfile{Name: name}
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	slog.Info("profile-create", "profile", name)
+	return response{OK: true}
+}
+
+// handleProfileSave copies the active custom profile under a new name. It does
+// not activate the copy: saving is a bookmark, not a switch.
+func (d *Daemon) handleProfileSave(req request) response {
+	name := strings.TrimSpace(req.Set)
+	if err := cli.ValidateProfileName(name); err != nil {
+		return response{OK: false, Error: "profile-save: " + err.Error()}
+	}
+	// hwMu for the same reason as handleProfileCreate.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	src, ok := d.state.ActiveCustomProfile()
+	if !ok {
+		d.mu.Unlock()
+		return response{OK: false, Error: "profile-save: no custom profile is active; there is nothing to copy"}
+	}
+	if src.Empty() {
+		d.mu.Unlock()
+		return response{OK: false, Error: "profile-save: the active profile has no settings to copy"}
+	}
+	p := cloneCustomProfile(src)
+	p.Name = name
+	if p.Undervolt != nil {
+		// Active describes hardware, and the copy is not the profile running.
+		p.Undervolt.Active = false
+	}
+	if d.state.CustomProfiles == nil {
+		d.state.CustomProfiles = make(map[string]api.CustomProfile, 1)
+	}
+	d.state.CustomProfiles[name] = p
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	slog.Info("profile-save", "profile", name, "from", src.Name)
+	return response{OK: true}
+}
+
+// handleProfileDelete removes a saved custom profile.
+//
+// It refuses to delete the active profile or one referenced by autoswitch.
+// Deleting the active one would leave state.Profile naming a profile that no
+// longer exists, which makes IsCustomProfile false and silently stops the
+// reconcile watcher defending a live custom fan curve — a thermal regression
+// with no log line. Both refusals are trivially reversible: switch away, or
+// reconfigure autoswitch, then delete.
+func (d *Daemon) handleProfileDelete(req request) response {
+	name := strings.ToLower(strings.TrimSpace(req.Set))
+	if name == "" {
+		return response{OK: false, Error: "profile-delete requires a set field"}
+	}
+	// hwMu for the same reason as handleProfileCreate. It also keeps a delete
+	// from landing part-way through applyProfileLocked, which would leave
+	// state.Profile naming a profile that no longer exists — and so stop the
+	// reconcile watcher defending a fan curve that is live in hardware.
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	if refusal := d.deleteRefusalLocked(name); refusal != "" {
+		d.mu.Unlock()
+		return response{OK: false, Error: "profile-delete: " + refusal}
+	}
+	delete(d.state.CustomProfiles, name)
+	s := cloneState(d.state)
+	d.mu.Unlock()
+	if err := saveState(s); err != nil {
+		slog.Warn("failed to save state", "err", err)
+	}
+	slog.Info("profile-delete", "profile", name)
+	return response{OK: true}
+}
+
+// deleteRefusalLocked returns the reason a profile may not be deleted, or "".
+// Caller must hold d.mu.
+func (d *Daemon) deleteRefusalLocked(name string) string {
+	if _, ok := d.state.CustomProfiles[name]; !ok {
+		return "no saved profile named " + name
+	}
+	if d.state.Profile == name {
+		return name + " is the active profile; switch to another profile first"
+	}
+	if a := d.state.Autoswitch; a != nil {
+		if a.AC == name {
+			return name + " is the autoswitch AC profile; change it first"
+		}
+		if a.Battery == name {
+			return name + " is the autoswitch battery profile; change it first"
+		}
+	}
+	return ""
+}
+
+// profileSummary is one row of profile-list. It reports which profile is active
+// so a client does not have to correlate against get-state.
+type profileSummary struct {
+	api.CustomProfile
+	Active bool `json:"active"`
+}
+
+func (d *Daemon) handleProfileList() response {
+	d.mu.Lock()
+	s := cloneState(d.state)
+	d.mu.Unlock()
+
+	names := make([]string, 0, len(s.CustomProfiles)+1)
+	for name := range s.CustomProfiles {
+		names = append(names, name)
+	}
+	// "custom" is always addressable even before it has ever been populated,
+	// so list it whether or not it has an entry.
+	if _, ok := s.CustomProfiles[api.DefaultCustomProfile]; !ok {
+		names = append(names, api.DefaultCustomProfile)
+	}
+	slices.Sort(names)
+
+	out := make([]profileSummary, 0, len(names))
+	for _, name := range names {
+		p := s.CustomProfiles[name]
+		p.Name = name
+		out = append(out, profileSummary{CustomProfile: p, Active: s.Profile == name})
+	}
+	data, _ := json.Marshal(out)
+	return response{OK: true, Value: string(data)}
+}

--- a/internal/daemon/profile.go
+++ b/internal/daemon/profile.go
@@ -141,9 +141,7 @@ func (d *Daemon) applyCustomHW(p api.CustomProfile) {
 	}
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 }
 
 // applyStockHW switches to a firmware profile.
@@ -174,9 +172,7 @@ func (d *Daemon) applyStockHW(profile string) error {
 	setUndervoltActive(d.state, false)
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return nil
 }
 
@@ -325,9 +321,7 @@ func (d *Daemon) handleProfileCreate(req request) response {
 	d.state.CustomProfiles[name] = api.CustomProfile{Name: name}
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	slog.Info("profile-create", "profile", name)
 	return response{OK: true}
 }
@@ -365,9 +359,7 @@ func (d *Daemon) handleProfileSave(req request) response {
 	d.state.CustomProfiles[name] = p
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	slog.Info("profile-save", "profile", name, "from", src.Name)
 	return response{OK: true}
 }
@@ -400,9 +392,7 @@ func (d *Daemon) handleProfileDelete(req request) response {
 	delete(d.state.CustomProfiles, name)
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	slog.Info("profile-delete", "profile", name)
 	return response{OK: true}
 }

--- a/internal/daemon/profile_test.go
+++ b/internal/daemon/profile_test.go
@@ -1,0 +1,330 @@
+package daemon
+
+// profile_test.go — profile-map invariants that no other test covers.
+//
+// Everything here stays on state-only paths. internal/cli's sysfs path vars are
+// unexported, so a daemon test that reached applyProfileLocked would rewrite the
+// developer's real power limits, fan mode, and Curve Optimizer offset.
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dahui/z13ctl/api"
+	"github.com/dahui/z13ctl/internal/cli"
+)
+
+// blockedFor reports whether fn was still running after d, used to check that a
+// handler really does wait on a lock. Long enough that a handler which does not
+// take the lock finishes first, short enough to keep the suite fast.
+func blockedFor(d time.Duration, done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// TestProfileMutatorsTakeHwMu is the regression guard for a resurrect-after-
+// delete race. The fancurve/tdp/undervolt handlers resolve a target under d.mu,
+// release it for the hardware write, then commit the profile back under d.mu.
+// A delete landing inside that window was undone by the commit, putting the
+// deleted profile back. hwMu is what makes the whole span exclusive, so the
+// profile mutators must take it even though they write no hardware themselves.
+func TestProfileMutatorsTakeHwMu(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	tests := []struct {
+		name string
+		call func(d *Daemon)
+	}{
+		{"profile-create", func(d *Daemon) { d.handleProfileCreate(request{Set: "fresh"}) }},
+		{"profile-save", func(d *Daemon) { d.handleProfileSave(request{Set: "copy"}) }},
+		{"profile-delete", func(d *Daemon) { d.handleProfileDelete(request{Set: "spare"}) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Daemon{state: api.State{
+				Profile: "gaming",
+				CustomProfiles: map[string]api.CustomProfile{
+					"gaming": {Name: "gaming", TDP: &api.TDPState{PL1SPL: 70}},
+					"spare":  {Name: "spare"},
+				},
+			}}
+			// Hold hwMu as an edit handler would while writing hardware.
+			d.hwMu.Lock()
+			done := make(chan struct{})
+			go func() { defer close(done); tt.call(d) }()
+
+			blocked := blockedFor(150*time.Millisecond, done)
+			d.hwMu.Unlock()
+			<-done
+
+			if !blocked {
+				t.Errorf("%s ran while hwMu was held; it can interleave with an edit handler's "+
+					"resolve-write-commit span and silently undo the commit", tt.name)
+			}
+		})
+	}
+}
+
+// TestApplyCustomHWClearsWhatTheProfileDoesNotSet states the invariant that
+// makes switching between two custom profiles predictable. It asserts on the
+// decision inputs rather than calling applyCustomHW, which writes hardware:
+// internal/cli's path vars are unexported, so invoking it here would change the
+// developer's real power limits, fan mode, and Curve Optimizer offset.
+//
+// The bug it guards: going from a profile with a 90 W limit and a -25 offset to
+// one that sets neither left both in force while the daemon reported the second
+// profile, so selecting A then B then A gave a different machine than A alone.
+func TestApplyCustomHWClearsWhatTheProfileDoesNotSet(t *testing.T) {
+	tests := []struct {
+		name           string
+		p              api.CustomProfile
+		wantWriteCurve bool
+		wantClearTDP   bool
+		wantResetCO    bool
+		wantReleaseFan bool
+	}{
+		{
+			name:           "a profile that sets nothing clears everything",
+			p:              api.CustomProfile{Name: "blank"},
+			wantClearTDP:   true,
+			wantResetCO:    true,
+			wantReleaseFan: true,
+		},
+		{
+			name:           "a curve-only profile clears the limits and the offset",
+			p:              api.CustomProfile{Name: "fans", FanCurve: &api.FanCurveState{Mode: 1, Points: curve(120)}},
+			wantWriteCurve: true,
+			wantClearTDP:   true,
+			wantResetCO:    true,
+		},
+		{
+			name:           "a TDP-only profile releases the fans and clears the offset",
+			p:              api.CustomProfile{Name: "watts", TDP: &api.TDPState{PL1SPL: 45}},
+			wantResetCO:    true,
+			wantReleaseFan: true,
+		},
+		{
+			// The floor ApplyTDPSafely just wrote must stand: releasing the fans
+			// here would drop it while the limit that requires it is in force.
+			name:         "a high-TDP profile with no curve keeps the high-TDP floor",
+			p:            api.CustomProfile{Name: "hot", TDP: &api.TDPState{PL1SPL: cli.TDPMaxSafe + 1}},
+			wantResetCO:  true,
+			wantClearTDP: false,
+		},
+		{
+			name:           "a fully-specified profile clears nothing",
+			p:              api.CustomProfile{Name: "all", FanCurve: &api.FanCurveState{Mode: 1, Points: curve(140)}, TDP: &api.TDPState{PL1SPL: 45}, Undervolt: &api.UndervoltState{CPUCO: -20}},
+			wantWriteCurve: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := tt.p
+			hasCurve := p.FanCurve != nil && p.FanCurve.Mode == 1 && len(p.FanCurve.Points) == 8
+			highTDP := p.TDP != nil && p.TDP.PL1SPL > cli.TDPMaxSafe
+
+			if hasCurve != tt.wantWriteCurve {
+				t.Errorf("writes the profile's curve = %v, want %v", hasCurve, tt.wantWriteCurve)
+			}
+			if clearTDP := p.TDP == nil; clearTDP != tt.wantClearTDP {
+				t.Errorf("hands the limits back to the firmware profile = %v, want %v", clearTDP, tt.wantClearTDP)
+			}
+			if resetCO := p.Undervolt == nil; resetCO != tt.wantResetCO {
+				t.Errorf("resets the Curve Optimizer = %v, want %v", resetCO, tt.wantResetCO)
+			}
+			if release := !hasCurve && !highTDP; release != tt.wantReleaseFan {
+				t.Errorf("releases the fans to firmware auto = %v, want %v", release, tt.wantReleaseFan)
+			}
+		})
+	}
+}
+
+// TestProfileNamesStayLowercaseInTheMap covers the strict-on-write,
+// lenient-on-lookup split: creating "Gaming" is refused, but selecting or
+// editing an existing profile folds case.
+func TestProfileNamesStayLowercaseInTheMap(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	d := &Daemon{state: api.State{Profile: "balanced"}}
+
+	if resp := d.handleProfileCreate(request{Set: "Gaming"}); resp.OK {
+		t.Error("profile-create accepted \"Gaming\"; the map key would not match what the user typed")
+	}
+	if resp := d.handleProfileCreate(request{Set: "gaming"}); !resp.OK {
+		t.Fatalf("profile-create gaming: %s", resp.Error)
+	}
+
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked("GAMING")
+	d.mu.Unlock()
+	if err != nil {
+		t.Fatalf("editing \"GAMING\" should fold to \"gaming\": %v", err)
+	}
+	if target.Name != "gaming" {
+		t.Errorf("edit target = %q, want \"gaming\"", target.Name)
+	}
+}
+
+// TestProfileCreateRejectsDuplicates keeps --create from silently wiping a
+// populated profile.
+func TestProfileCreateRejectsDuplicates(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	d := &Daemon{state: api.State{
+		CustomProfiles: map[string]api.CustomProfile{
+			"gaming": {Name: "gaming", TDP: &api.TDPState{PL1SPL: 70}},
+		},
+	}}
+	if resp := d.handleProfileCreate(request{Set: "gaming"}); resp.OK {
+		t.Fatal("profile-create overwrote an existing profile")
+	}
+	if d.state.CustomProfiles["gaming"].TDP == nil {
+		t.Error("the existing profile's settings were cleared by the refused create")
+	}
+}
+
+// TestProfileSaveZeroesUndervoltActive covers a bug generator: Active describes
+// hardware, so a copy taken while an offset was applied must not claim to be
+// applied itself.
+func TestProfileSaveZeroesUndervoltActive(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	d := &Daemon{state: api.State{
+		Profile: "gaming",
+		CustomProfiles: map[string]api.CustomProfile{
+			"gaming": {Name: "gaming", Undervolt: &api.UndervoltState{CPUCO: -25, Active: true}},
+		},
+	}}
+	if resp := d.handleProfileSave(request{Set: "copy"}); !resp.OK {
+		t.Fatalf("profile-save: %s", resp.Error)
+	}
+	cp := d.state.CustomProfiles["copy"]
+	if cp.Undervolt == nil || cp.Undervolt.CPUCO != -25 {
+		t.Fatalf("copied undervolt = %+v, want CO -25", cp.Undervolt)
+	}
+	if cp.Undervolt.Active {
+		t.Error("the copy claims its undervolt is applied to hardware, but only the original is")
+	}
+	cp.Undervolt.CPUCO = -1
+	if d.state.CustomProfiles["gaming"].Undervolt.CPUCO != -25 {
+		t.Error("profile-save aliased the source profile's undervolt pointer")
+	}
+}
+
+// TestProfileSaveRefusesWithNothingToCopy keeps an empty profile out of the map.
+func TestProfileSaveRefusesWithNothingToCopy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	for _, s := range []api.State{
+		{Profile: "balanced"}, // a firmware profile is active
+		{Profile: "custom"},   // custom exists but holds nothing
+	} {
+		d := &Daemon{state: s}
+		if resp := d.handleProfileSave(request{Set: "copy"}); resp.OK {
+			t.Errorf("profile-save with Profile=%q was accepted, want a rejection", s.Profile)
+		}
+	}
+}
+
+// TestSetUndervoltActiveStampsEveryProfile covers the global-hardware argument:
+// Curve Optimizer is one register, so at most one profile's offset can be live.
+func TestSetUndervoltActiveStampsEveryProfile(t *testing.T) {
+	s := api.State{CustomProfiles: map[string]api.CustomProfile{
+		"a": {Name: "a", Undervolt: &api.UndervoltState{CPUCO: -10, Active: true}},
+		"b": {Name: "b", Undervolt: &api.UndervoltState{CPUCO: -20, Active: true}},
+		"c": {Name: "c"},
+	}}
+	setUndervoltActive(s, false)
+	for name, p := range s.CustomProfiles {
+		if p.Undervolt != nil && p.Undervolt.Active {
+			t.Errorf("profile %q still claims its undervolt is applied", name)
+		}
+	}
+}
+
+// TestConcurrentProfileMutationIsRaceFree exercises the map under -race through
+// the paths a GUI would drive.
+func TestConcurrentProfileMutationIsRaceFree(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	d := &Daemon{state: api.State{
+		Profile:        "balanced",
+		CustomProfiles: map[string]api.CustomProfile{"keep": {Name: "keep", TDP: &api.TDPState{PL1SPL: 40}}},
+	}}
+
+	var wg sync.WaitGroup
+	for i := range 4 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := "p" + string(rune('a'+i))
+			for range 50 {
+				d.handleProfileCreate(request{Set: name})
+				d.handleProfileList()
+				d.handleAutoswitchGet()
+				d.handleProfileDelete(request{Set: name})
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if _, ok := d.state.CustomProfiles["keep"]; !ok {
+		t.Error("the untouched profile disappeared")
+	}
+}
+
+func TestDeleteRefusalMessages(t *testing.T) {
+	d := &Daemon{state: api.State{
+		Profile: "gaming",
+		CustomProfiles: map[string]api.CustomProfile{
+			"gaming": {Name: "gaming"}, "ac-one": {Name: "ac-one"}, "bat-one": {Name: "bat-one"},
+		},
+		Autoswitch: &api.AutoswitchState{Enabled: true, AC: "ac-one", Battery: "bat-one"},
+	}}
+	for target, want := range map[string]string{
+		"gaming":  "active profile",
+		"ac-one":  "autoswitch AC profile",
+		"bat-one": "autoswitch battery profile",
+		"missing": "no saved profile",
+	} {
+		if got := d.deleteRefusalLocked(target); !strings.Contains(got, want) {
+			t.Errorf("deleteRefusalLocked(%q) = %q, want it to mention %q", target, got, want)
+		}
+	}
+}
+
+// TestAutoswitchValidationOrderIsStable keeps the reported side deterministic
+// when both are wrong — a map range would name a different one each run.
+func TestAutoswitchValidationOrderIsStable(t *testing.T) {
+	for range 20 {
+		d := &Daemon{state: api.State{}}
+		resp := d.handleAutoswitch(request{Enabled: true, AC: "nope-ac", Battery: "nope-bat"})
+		if resp.OK {
+			t.Fatal("autoswitch accepted two unknown targets")
+		}
+		if !strings.Contains(resp.Error, "nope-ac") {
+			t.Fatalf("error = %q, want the AC side reported first every time", resp.Error)
+		}
+	}
+}
+
+// TestAutoswitchDisableIsAlwaysAllowed covers the escape hatch: turning
+// autoswitch off must work even when a target has gone stale, or it stays
+// enabled with no way back short of editing the state file.
+func TestAutoswitchDisableIsAlwaysAllowed(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	d := &Daemon{state: api.State{}}
+
+	if resp := d.handleAutoswitch(request{Enabled: true, Battery: "ghost"}); resp.OK {
+		t.Fatal("enabling with an unknown target was accepted")
+	}
+	resp := d.handleAutoswitch(request{Enabled: false, AC: "ghost", Battery: "ghost"})
+	if !resp.OK {
+		t.Fatalf("disabling with a stale target was refused: %s", resp.Error)
+	}
+	if d.state.Autoswitch == nil || d.state.Autoswitch.Enabled {
+		t.Errorf("autoswitch = %+v, want it disabled", d.state.Autoswitch)
+	}
+}

--- a/internal/daemon/reconcile.go
+++ b/internal/daemon/reconcile.go
@@ -46,9 +46,9 @@ const reconcileQuietAfter = 3
 // reconcileObs is one observation: what daemon state says should be in force,
 // and what the hardware currently reports.
 type reconcileObs struct {
-	Profile   string              // effective profile from daemon state
-	WantCurve []api.FanCurvePoint // saved custom curve; nil if none
-	WantTDP   *api.TDPState       // saved custom TDP; nil if none
+	Custom    bool                // daemon state says a custom profile is active
+	WantCurve []api.FanCurvePoint // that profile's curve; nil if none
+	WantTDP   *api.TDPState       // that profile's TDP; nil if none
 	CurveMode int                 // curve device pwm1_enable; -1 if unreadable
 	PL1       int                 // effective sustained limit in watts; -1 if unreadable
 	ProfileHW string              // platform_profile, for logging only
@@ -81,11 +81,13 @@ func reconcileTick(prev reconcileState, obs reconcileObs) (reconcileState, recon
 	st := prev
 	st.lastHW = obs.ProfileHW
 
-	// Only "custom" means the daemon is claiming ownership of fans and PPT.
-	// Every route to a stock profile — handleProfile, handleTDPReset,
+	// Only a custom profile means the daemon is claiming ownership of fans and
+	// PPT. Every route to a stock profile — handleProfile, handleTDPReset,
 	// handleFanCurveReset — updates state first, so this is what keeps the
-	// watcher from fighting a legitimate profile switch.
-	if obs.Profile != "custom" {
+	// watcher from fighting a legitimate profile switch. A firmware profile name
+	// is never custom even if a profile of that name somehow reached the map,
+	// so this cannot be subverted by a hand-edited state file.
+	if !obs.Custom {
 		st.failures = 0
 		st.quiet = false
 		return st, reconcileAction{}
@@ -177,14 +179,16 @@ func (d *Daemon) reconcileOnce(prev reconcileState) reconcileState {
 	d.mu.Unlock()
 
 	obs := reconcileObs{
-		Profile:   s.Profile,
 		CurveMode: -1,
 		PL1:       -1,
 	}
-	if s.FanCurve != nil && s.FanCurve.Mode == 1 && len(s.FanCurve.Points) == 8 {
-		obs.WantCurve = s.FanCurve.Points
+	if active, ok := s.ActiveCustomProfile(); ok {
+		obs.Custom = true
+		if fc := active.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
+			obs.WantCurve = fc.Points
+		}
+		obs.WantTDP = active.TDP
 	}
-	obs.WantTDP = s.TDP
 
 	// Cheap enough to read unconditionally, and reading them even when the
 	// profile is stock keeps lastHW meaningful for the log line.

--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -23,6 +23,39 @@ func curve(pwm int) []api.FanCurvePoint {
 	return points
 }
 
+// TestReconcileCustomFlagFollowsTheProfileMap covers what feeds obs.Custom:
+// reconcileOnce derives it from ActiveCustomProfile, so a named profile must
+// be defended exactly as "custom" is, and a stale or reserved name must not be.
+// The apply path itself cannot be exercised here — internal/cli's path vars are
+// unexported, so it would write the developer's real fan hardware.
+func TestReconcileCustomFlagFollowsTheProfileMap(t *testing.T) {
+	profiles := map[string]api.CustomProfile{
+		"battery-uv": {Name: "battery-uv", FanCurve: &api.FanCurveState{Mode: 1, Points: curve(120)}},
+		"balanced":   {Name: "balanced"}, // a hand-edited state file
+	}
+	tests := []struct {
+		profile string
+		want    bool
+	}{
+		{"battery-uv", true},
+		{api.DefaultCustomProfile, true},
+		{"balanced", false}, // reserved: the firmware profile always wins
+		{"performance", false},
+		{"deleted-profile", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		s := api.State{Profile: tt.profile, CustomProfiles: profiles}
+		active, ok := s.ActiveCustomProfile()
+		if ok != tt.want {
+			t.Errorf("ActiveCustomProfile() with Profile=%q returned ok=%v, want %v", tt.profile, ok, tt.want)
+		}
+		if ok && tt.profile == "battery-uv" && active.FanCurve == nil {
+			t.Error("the named profile's curve did not reach the watcher, so it would not be defended")
+		}
+	}
+}
+
 func TestReconcileTick(t *testing.T) {
 	saved := curve(120)
 	floorTDP := &api.TDPState{PL1SPL: 90, PL2SPPT: 90, FPPT: 90}
@@ -36,37 +69,33 @@ func TestReconcileTick(t *testing.T) {
 	}{
 		{
 			name: "stock profile is left alone even with hardware in auto",
-			obs:  reconcileObs{Profile: "balanced", WantCurve: saved, CurveMode: 2, PL1: 35},
-		},
-		{
-			name: "empty profile is not custom",
-			obs:  reconcileObs{Profile: "", WantCurve: saved, CurveMode: 2, PL1: 35},
+			obs:  reconcileObs{Custom: false, WantCurve: saved, CurveMode: 2, PL1: 35},
 		},
 		{
 			name: "curve still live: nothing to do",
-			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 1, PL1: 35},
+			obs:  reconcileObs{Custom: true, WantCurve: saved, CurveMode: 1, PL1: 35},
 		},
 		{
 			name: "unreadable mode: never act on an unknown",
-			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: -1, PL1: 35},
+			obs:  reconcileObs{Custom: true, WantCurve: saved, CurveMode: -1, PL1: 35},
 		},
 		{
 			name: "full speed is more cooling than we would write",
-			obs:  reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 0, PL1: 90},
+			obs:  reconcileObs{Custom: true, WantCurve: saved, CurveMode: 0, PL1: 90},
 		},
 		{
 			name:      "dropped to auto with a saved curve",
-			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: 35},
+			obs:       reconcileObs{Custom: true, WantCurve: saved, CurveMode: 2, PL1: 35},
 			wantCurve: true,
 		},
 		{
 			name:      "unreadable PPT does not block restoring a saved curve",
-			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: -1},
+			obs:       reconcileObs{Custom: true, WantCurve: saved, CurveMode: 2, PL1: -1},
 			wantCurve: true,
 		},
 		{
 			name:      "no saved curve but the high-TDP floor is required",
-			obs:       reconcileObs{Profile: "custom", CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			obs:       reconcileObs{Custom: true, CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
 			wantCurve: true,
 			wantFloor: true,
 		},
@@ -76,36 +105,36 @@ func TestReconcileTick(t *testing.T) {
 			// leaves a sub-floor curve in state. Restoring it would undo the
 			// floor at the moment it is needed.
 			name:      "saved curve below the floor while the limit is high",
-			obs:       reconcileObs{Profile: "custom", WantCurve: saved, CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			obs:       reconcileObs{Custom: true, WantCurve: saved, CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
 			wantCurve: true,
 			wantFloor: true,
 		},
 		{
 			name:      "saved curve already meets the floor",
-			obs:       reconcileObs{Profile: "custom", WantCurve: curve(cli.HighTDPMinPWM), CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
+			obs:       reconcileObs{Custom: true, WantCurve: curve(cli.HighTDPMinPWM), CurveMode: 2, PL1: cli.TDPMaxSafe + 1},
 			wantCurve: true,
 			wantFloor: true, // its own points are at the floor
 		},
 		{
 			name: "no saved curve and the limit is safe",
-			obs:  reconcileObs{Profile: "custom", CurveMode: 2, PL1: cli.TDPMaxSafe},
+			obs:  reconcileObs{Custom: true, CurveMode: 2, PL1: cli.TDPMaxSafe},
 		},
 		{
 			name: "no saved curve and PPT unreadable",
-			obs:  reconcileObs{Profile: "custom", CurveMode: 2, PL1: -1},
+			obs:  reconcileObs{Custom: true, CurveMode: 2, PL1: -1},
 		},
 		{
 			name:    "PPT drifted from the saved custom value",
-			obs:     reconcileObs{Profile: "custom", CurveMode: 1, PL1: 35, WantTDP: floorTDP},
+			obs:     reconcileObs{Custom: true, CurveMode: 1, PL1: 35, WantTDP: floorTDP},
 			wantTDP: true,
 		},
 		{
 			name: "PPT matches the saved value",
-			obs:  reconcileObs{Profile: "custom", CurveMode: 1, PL1: 90, WantTDP: floorTDP},
+			obs:  reconcileObs{Custom: true, CurveMode: 1, PL1: 90, WantTDP: floorTDP},
 		},
 		{
 			name: "unreadable PPT is not a TDP mismatch",
-			obs:  reconcileObs{Profile: "custom", CurveMode: 1, PL1: -1, WantTDP: floorTDP},
+			obs:  reconcileObs{Custom: true, CurveMode: 1, PL1: -1, WantTDP: floorTDP},
 		},
 	}
 
@@ -139,7 +168,7 @@ func TestReconcileTick(t *testing.T) {
 // restore which can never succeed — revoked permissions, an unbound driver —
 // from writing a warning to the journal every two seconds forever.
 func TestReconcileTickQuietsAfterRepeatedFailure(t *testing.T) {
-	obs := reconcileObs{Profile: "custom", WantCurve: curve(120), CurveMode: 2, PL1: 35}
+	obs := reconcileObs{Custom: true, WantCurve: curve(120), CurveMode: 2, PL1: 35}
 
 	// The loop increments failures itself; the tick must not clear them while
 	// the hardware still disagrees.
@@ -154,7 +183,7 @@ func TestReconcileTickQuietsAfterRepeatedFailure(t *testing.T) {
 
 	// A tick with nothing to do clears the latch, so the next real failure is
 	// logged again.
-	st, act = reconcileTick(st, reconcileObs{Profile: "custom", CurveMode: 1, PL1: 35})
+	st, act = reconcileTick(st, reconcileObs{Custom: true, CurveMode: 1, PL1: 35})
 	if !act.none() {
 		t.Fatalf("tick acted on a live curve: %+v", act)
 	}
@@ -165,7 +194,7 @@ func TestReconcileTickQuietsAfterRepeatedFailure(t *testing.T) {
 
 func TestReconcileTickTracksProfileForLogging(t *testing.T) {
 	st, _ := reconcileTick(reconcileState{lastHW: "performance"},
-		reconcileObs{Profile: "custom", CurveMode: 1, ProfileHW: "balanced"})
+		reconcileObs{Custom: true, CurveMode: 1, ProfileHW: "balanced"})
 	if st.lastHW != "balanced" {
 		t.Errorf("lastHW = %q, want \"balanced\"", st.lastHW)
 	}

--- a/internal/daemon/resume.go
+++ b/internal/daemon/resume.go
@@ -13,7 +13,6 @@ import (
 	"github.com/godbus/dbus/v5"
 
 	"github.com/dahui/z13ctl/internal/aura"
-	"github.com/dahui/z13ctl/internal/cli"
 )
 
 // watchResume connects to the system DBus and listens for resume events.
@@ -100,47 +99,24 @@ func (d *Daemon) restoreVolatileState() {
 	}
 	d.mu.Unlock()
 
-	if state.Profile != "custom" {
-		slog.Info("skipping volatile state restore (stock profile active)", "profile", state.Profile)
+	// The power source may have changed while the machine was asleep. There is
+	// deliberately no autoswitch hook here: Go timers use CLOCK_MONOTONIC and do
+	// not advance across suspend, so the power-source watcher's armed timer
+	// fires promptly after resume and handles it. Duplicating the logic here
+	// would race that watcher over hwMu and apply twice for one event. The cost
+	// is a few seconds during which the pre-sleep profile is back in force,
+	// which ApplyTDPSafely still keeps within the thermal floor.
+	active, ok := state.ActiveCustomProfile()
+	if !ok || active.Empty() {
+		slog.Info("skipping volatile state restore (no custom profile active)", "profile", state.Profile)
 		return
 	}
 
-	// Restore fan curve.
-	if fc := state.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
-		if err := cli.SetBothFanCurves(fc.Points); err != nil {
-			slog.Warn("resume: failed to restore fan curve", "err", err)
-		} else {
-			slog.Info("resume: fan curve restored")
-		}
-	}
-
-	// Restore TDP. ApplyTDPSafely raises the fans to the 50% floor first when the
-	// sustained limit exceeds the safe max, and declines to apply the TDP at all
-	// if that fails.
-	if t := state.TDP; t != nil {
-		if err := cli.ApplyTDPSafely(*t); err != nil {
-			slog.Warn("resume: failed to restore TDP", "err", err)
-		} else {
-			slog.Info("resume: TDP restored", "pl1", t.PL1SPL, "pl2", t.PL2SPPT, "pl3", t.FPPT)
-		}
-	}
-
-	// Restore undervolt.
-	if uv := state.Undervolt; uv != nil && cli.SMUProbeUndervolt() {
-		d.mu.Lock()
-		if d.state.Undervolt != nil {
-			d.state.Undervolt.Active = false
-		}
-		d.mu.Unlock()
-		if err := cli.SetCurveOptimizer(uv.CPUCO); err != nil {
-			slog.Warn("resume: failed to restore undervolt", "err", err)
-		} else {
-			d.mu.Lock()
-			if d.state.Undervolt != nil {
-				d.state.Undervolt.Active = true
-			}
-			d.mu.Unlock()
-			slog.Info("resume: undervolt restored", "cpu", uv.CPUCO)
-		}
-	}
+	// Through the same helper as the socket command, the autoswitch watcher and
+	// daemon startup. Resume used to carry its own copy of the apply sequence,
+	// which is how the four drifted apart in the first place; every fix to the
+	// ordering or the clearing rules now lands here too. hwMu is already held,
+	// which is what applyCustomHW requires.
+	slog.Info("resume: restoring custom profile", "profile", active.Name)
+	d.applyCustomHW(active)
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -40,6 +40,13 @@ type request struct {
 	PL2        string   `json:"pl2,omitempty"`
 	PL3        string   `json:"pl3,omitempty"`
 	Force      bool     `json:"force,omitempty"`
+	// Profile names the custom profile a fancurve/tdp/undervolt command edits.
+	// Empty means the active profile — which is what every client written before
+	// this field existed sends, so their behaviour is unchanged.
+	Profile string `json:"profile,omitempty"`
+	AC      string `json:"ac,omitempty"`
+	Battery string `json:"battery,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
 }
 
 // response is the reply to a command or a streamed event notification.
@@ -111,6 +118,18 @@ func (d *Daemon) dispatch(req request) response {
 		return d.handleProfile(req)
 	case "profile-get":
 		return handleProfileGet()
+	case "profile-create":
+		return d.handleProfileCreate(req)
+	case "profile-save":
+		return d.handleProfileSave(req)
+	case "profile-delete":
+		return d.handleProfileDelete(req)
+	case "profile-list":
+		return d.handleProfileList()
+	case "autoswitch":
+		return d.handleAutoswitch(req)
+	case "autoswitch-get":
+		return d.handleAutoswitchGet()
 	case "batterylimit":
 		return d.handleBatteryLimit(req)
 	case "batterylimit-get":
@@ -128,23 +147,30 @@ func (d *Daemon) dispatch(req request) response {
 	case "fancurve-get":
 		return handleFanCurveGet()
 	case "fancurve-reset":
-		return d.handleFanCurveReset()
+		return d.handleFanCurveReset(req)
 	case "tdp":
 		return d.handleTDP(req)
 	case "tdp-get":
 		return d.handleTDPGet()
 	case "tdp-reset":
-		return d.handleTDPReset()
+		return d.handleTDPReset(req)
 	case "undervolt":
 		return d.handleUndervolt(req)
 	case "undervolt-get":
 		return d.handleUndervoltGet()
 	case "undervolt-reset":
-		return d.handleUndervoltReset()
+		return d.handleUndervoltReset(req)
 	case "get-state":
 		d.mu.Lock()
-		s := cloneState(d.state)
+		// The legacy FanCurve/TDP/Undervolt fields are projected here from the
+		// active custom profile so clients written before named profiles existed
+		// still see the settings that are in force. Two of the three are then
+		// overwritten with live sysfs readings below.
+		s := withLegacyProjection(cloneState(d.state))
 		d.mu.Unlock()
+		if onAC, acErr := cli.OnACPower(); acErr == nil {
+			s.OnAC = onAC
+		}
 		// Populate firmware-managed fields from sysfs (not cached in daemon state).
 		s.BootSound = readIntSysfs(cli.FindBootSoundPath())
 		s.PanelOverdrive = readIntSysfs(cli.FindPanelOverdrivePath())
@@ -353,100 +379,6 @@ func (d *Daemon) handleBrightness(req request) response {
 	return response{OK: true}
 }
 
-func (d *Daemon) handleProfile(req request) response {
-	if req.Set == "" {
-		return response{OK: false, Error: "profile requires a set field"}
-	}
-
-	profile := strings.ToLower(req.Set)
-
-	d.hwMu.Lock()
-	defer d.hwMu.Unlock()
-
-	// "custom" is a virtual profile: re-apply saved fan curve + TDP + UV.
-	if profile == "custom" {
-		// Snapshot under d.mu, then do the hardware work unlocked. Holding d.mu
-		// across cli.* calls — as this branch used to — takes d.mu before hwMu
-		// and inverts the lock order the rest of the daemon follows.
-		d.mu.Lock()
-		if d.state.FanCurve == nil && d.state.TDP == nil && d.state.Undervolt == nil {
-			d.mu.Unlock()
-			return response{OK: false, Error: "no custom settings saved; set fan curve, TDP, or undervolt first"}
-		}
-		d.state.Profile = "custom"
-		saved := cloneState(d.state)
-		d.mu.Unlock()
-
-		// Re-apply saved fan curve to both fans.
-		if fc := saved.FanCurve; fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
-			if err := cli.SetBothFanCurves(fc.Points); err != nil {
-				slog.Warn("failed to reapply fan curve", "err", err)
-			}
-		}
-		// Re-apply saved TDP. ApplyTDPSafely raises the fans to the 50% floor
-		// before raising power (this branch used to do it the other way round,
-		// and discarded the fan error) and refuses the TDP if that write fails.
-		if t := saved.TDP; t != nil {
-			if err := cli.ApplyTDPSafely(*t); err != nil {
-				slog.Warn("failed to reapply TDP", "err", err)
-			}
-		}
-		// Re-apply saved undervolt.
-		uvActive := false
-		if uv := saved.Undervolt; uv != nil && cli.SMUProbeUndervolt() {
-			if err := cli.SetCurveOptimizer(uv.CPUCO); err != nil {
-				slog.Warn("failed to reapply undervolt", "err", err)
-			} else {
-				uvActive = true
-			}
-		}
-
-		d.mu.Lock()
-		if uvActive && d.state.Undervolt != nil {
-			d.state.Undervolt.Active = true
-		}
-		s := cloneState(d.state)
-		d.mu.Unlock()
-		slog.Info("profile", "set", "custom")
-		if err := saveState(s); err != nil {
-			slog.Warn("failed to save state", "err", err)
-		}
-		return response{OK: true}
-	}
-
-	// Stock profile: reset UV to stock, write platform_profile, restore that
-	// profile's stock PPT, and only then release the fans to firmware auto. The
-	// firmware manages fan curves for stock profiles, but it does NOT re-apply
-	// per-profile PPT, so any custom watts would otherwise persist across the
-	// switch — restoreStockPPT does that explicitly. Fans are released last so
-	// they are never dropped to auto while a high custom TDP is still in force.
-	if cli.SMUProbeUndervolt() {
-		if err := cli.ResetCurveOptimizer(); err != nil {
-			slog.Warn("failed to reset undervolt", "err", err)
-		}
-	}
-	if err := cli.SetProfile(profile); err != nil {
-		return response{OK: false, Error: "profile: " + err.Error()}
-	}
-	restoreStockPPT(profile)
-	if err := cli.ResetAllFanCurves(); err != nil {
-		slog.Warn("failed to reset fan curves to auto", "err", err)
-	}
-
-	slog.Info("profile", "set", profile)
-	d.mu.Lock()
-	d.state.Profile = profile
-	if d.state.Undervolt != nil {
-		d.state.Undervolt.Active = false
-	}
-	s := cloneState(d.state)
-	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
-	return response{OK: true}
-}
-
 // restoreStockPPT writes the measured stock PPT values for a stock profile back
 // to hardware. The asus-nb-wmi PPT attributes have no "reset to firmware
 // default" operation and the firmware does not re-apply per-profile limits on a
@@ -584,21 +516,38 @@ func (d *Daemon) handleFanCurve(req request) response {
 	}
 	d.hwMu.Lock()
 	defer d.hwMu.Unlock()
-	// Enforce the minimum PWM floor when sustained TDP exceeds the safe max.
-	// This reads hardware rather than the cached d.state.TDP, which can disagree
-	// with it — a TDP set while the daemon was down, or a reset state file — and
-	// silently skipped the guard. Matches the CLI's direct path.
-	if err := cli.CheckFanCurveFloor(d.effectiveProfile(), points); err != nil {
-		return response{OK: false, Error: "fancurve: " + err.Error()}
-	}
-	if err := cli.SetBothFanCurves(points); err != nil {
-		return response{OK: false, Error: "fancurve: " + err.Error()}
-	}
-	slog.Info("fancurve", "fans", "both")
+
 	d.mu.Lock()
-	d.state.FanCurve = &api.FanCurveState{Mode: 1, Points: points}
-	d.state.Profile = "custom"
-	s := cloneState(d.state)
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
+		return response{OK: false, Error: "fancurve: " + err.Error()}
+	}
+	d.mu.Unlock()
+
+	// Enforce the minimum PWM floor when the sustained TDP that will accompany
+	// this curve exceeds the safe max. For the live profile that limit comes
+	// from hardware, which is ground truth and can disagree with cached state —
+	// a TDP set while the daemon was down, or a reset state file. For any other
+	// profile it comes from that profile's own saved TDP, so a profile can never
+	// be stored in a state that would be unsafe the moment it is activated.
+	if err := cli.CheckCurveAgainstTDP(points, d.floorLimitFor(target)); err != nil {
+		return response{OK: false, Error: "fancurve: " + err.Error()}
+	}
+
+	if target.Live {
+		if err := cli.SetBothFanCurves(points); err != nil {
+			return response{OK: false, Error: "fancurve: " + err.Error()}
+		}
+		slog.Info("fancurve", "fans", "both", "profile", target.Name)
+	} else {
+		slog.Info("fancurve", "profile", target.Name, "applied", false)
+	}
+
+	p := target.Profile
+	p.FanCurve = &api.FanCurveState{Mode: 1, Points: points}
+	d.mu.Lock()
+	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
 		slog.Warn("failed to save state", "err", err)
@@ -606,22 +555,40 @@ func (d *Daemon) handleFanCurve(req request) response {
 	return response{OK: true}
 }
 
-func (d *Daemon) handleFanCurveReset() response {
+func (d *Daemon) handleFanCurveReset(req request) response {
 	d.hwMu.Lock()
 	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
+		return response{OK: false, Error: "fancurve-reset: " + err.Error()}
+	}
+	d.mu.Unlock()
+
 	// Firmware auto has no PWM floor, so releasing the fans while a high
 	// sustained TDP is still in force removes the very protection the high-TDP
-	// curve provides. "tdp --reset" is the way out — it lowers power first.
-	if err := cli.CheckFanFloorRelease(d.effectiveProfile()); err != nil {
+	// curve provides. "tdp --reset" is the way out — it lowers power first. The
+	// same reasoning applies to clearing the curve from a profile that keeps a
+	// high TDP: it would be unsafe the moment that profile is activated.
+	if err := cli.CheckFanFloorReleaseAt(d.floorLimitFor(target)); err != nil {
 		return response{OK: false, Error: "fancurve-reset: " + err.Error()}
 	}
-	if err := cli.ResetAllFanCurves(); err != nil {
-		return response{OK: false, Error: "fancurve-reset: " + err.Error()}
+
+	if target.Live {
+		if err := cli.ResetAllFanCurves(); err != nil {
+			return response{OK: false, Error: "fancurve-reset: " + err.Error()}
+		}
+		slog.Info("fancurve-reset", "fans", "both", "profile", target.Name)
+	} else {
+		slog.Info("fancurve-reset", "profile", target.Name, "applied", false)
 	}
-	slog.Info("fancurve-reset", "fans", "both")
+
+	p := target.Profile
+	p.FanCurve = nil
 	d.mu.Lock()
-	d.state.FanCurve = nil
-	s := cloneState(d.state)
+	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
 		slog.Warn("failed to save state", "err", err)
@@ -705,44 +672,100 @@ func (d *Daemon) handleTDP(req request) response {
 	d.hwMu.Lock()
 	defer d.hwMu.Unlock()
 
-	// ApplyTDPSafely raises the fans to the 50% floor first when pl1 exceeds the
-	// safe sustained max, and refuses to apply the TDP at all if that fails.
-	tdp := cli.TDPStateFor(watts, pl1, pl2, pl3)
-	if err := cli.ApplyTDPSafely(tdp); err != nil {
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
 		return response{OK: false, Error: "tdp: " + err.Error()}
 	}
-	if pl1 > cli.TDPMaxSafe {
-		slog.Warn("fans set to 50%+ curve for high TDP", "pl1", pl1)
-	}
-	slog.Info("tdp", "pl1", pl1, "pl2", pl2, "pl3", pl3)
+	d.mu.Unlock()
 
+	tdp := cli.TDPStateFor(watts, pl1, pl2, pl3)
+
+	// A profile that is not running must still be storable only in a state that
+	// is safe to activate: a high sustained limit alongside a curve that dips
+	// below the floor would be refused at activation, so refuse it here where
+	// the user can see why. The live profile needs no equivalent check —
+	// ApplyTDPSafely raises the floor itself.
+	if !target.Live && target.Profile.FanCurve != nil {
+		if err := cli.CheckCurveAgainstTDP(target.Profile.FanCurve.Points, pl1); err != nil {
+			return response{OK: false, Error: "tdp: " + err.Error() + " (stored in profile " + target.Name + ")"}
+		}
+	}
+
+	fc := target.Profile.FanCurve
+	if target.Live {
+		// ApplyTDPSafely raises the fans to the 50% floor first when pl1 exceeds
+		// the safe sustained max, and refuses to apply the TDP at all if that
+		// fails.
+		if err := cli.ApplyTDPSafely(tdp); err != nil {
+			return response{OK: false, Error: "tdp: " + err.Error()}
+		}
+		if pl1 > cli.TDPMaxSafe {
+			slog.Warn("fans set to 50%+ curve for high TDP", "pl1", pl1)
+		}
+		slog.Info("tdp", "pl1", pl1, "pl2", pl2, "pl3", pl3, "profile", target.Name)
+	} else {
+		slog.Info("tdp", "pl1", pl1, "pl2", pl2, "pl3", pl3, "profile", target.Name, "applied", false)
+	}
+
+	p := target.Profile
+	p.TDP = &tdp
 	d.mu.Lock()
-	d.state.TDP = &tdp
-	d.state.Profile = "custom"
-	fc := d.state.FanCurve
-	s := cloneState(d.state)
+	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
 		slog.Warn("failed to save state", "err", err)
 	}
 
-	// If sustained TDP is now safe, restore saved fan curve (undo high-TDP curve).
-	if pl1 <= cli.TDPMaxSafe {
+	// With the limit safe again, put the fans back to what the profile actually
+	// describes: its own curve, or firmware auto when it has none. Releasing
+	// them in the second case is the part that used to be missing — the
+	// high-TDP floor stayed applied to a profile holding no curve, so the same
+	// profile gave a different machine depending on whether it was reached by
+	// lowering the TDP or by selecting it, which applyCustomHW does not do.
+	if target.Live && pl1 <= cli.TDPMaxSafe {
 		if fc != nil && fc.Mode == 1 && len(fc.Points) == 8 {
 			if err := cli.SetBothFanCurves(fc.Points); err != nil {
 				slog.Warn("failed to restore fan curve after TDP change", "err", err)
 			} else {
 				slog.Info("fan curve restored after TDP reduced to safe levels")
 			}
+		} else if err := cli.ResetAllFanCurves(); err != nil {
+			slog.Warn("failed to release fans after TDP reduced to safe levels", "err", err)
 		}
 	}
 
 	return response{OK: true}
 }
 
-func (d *Daemon) handleTDPReset() response {
+// handleTDPReset lands on the balanced firmware profile when it targets the
+// live profile, and merely clears the stored limits when it targets another.
+func (d *Daemon) handleTDPReset(req request) response {
 	d.hwMu.Lock()
 	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
+		return response{OK: false, Error: "tdp-reset: " + err.Error()}
+	}
+	d.mu.Unlock()
+
+	if !target.Live {
+		p := target.Profile
+		p.TDP = nil
+		d.mu.Lock()
+		s := d.commitEditLocked(target, p)
+		d.mu.Unlock()
+		if err := saveState(s); err != nil {
+			slog.Warn("failed to save state", "err", err)
+		}
+		slog.Info("tdp-reset", "profile", target.Name, "applied", false)
+		return response{OK: true}
+	}
+
 	// Lower power first, then release the fans: balanced's sustained limit is
 	// below TDPMaxSafe, so by the time the fans drop to firmware auto the limit
 	// that required the 50% floor is gone. Doing it the other way round leaves a
@@ -768,12 +791,18 @@ func (d *Daemon) handleTDPReset() response {
 	}
 	slog.Info("tdp-reset", "profile", "balanced")
 	d.mu.Lock()
-	d.state.TDP = nil
-	d.state.FanCurve = nil
-	d.state.Profile = "balanced"
-	if d.state.Undervolt != nil {
-		d.state.Undervolt.Active = false
+	// Clear the limits and curve from the profile that was running, not from a
+	// global slot: switching back to it later must not resurrect the TDP this
+	// command just reset in hardware.
+	p := target.Profile
+	p.TDP = nil
+	p.FanCurve = nil
+	if d.state.CustomProfiles == nil {
+		d.state.CustomProfiles = make(map[string]api.CustomProfile, 1)
 	}
+	d.state.CustomProfiles[target.Name] = p
+	d.state.Profile = "balanced"
+	setUndervoltActive(d.state, false)
 	s := cloneState(d.state)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
@@ -787,8 +816,13 @@ func (d *Daemon) handleUndervoltGet() response {
 		return response{OK: false, Error: "Curve Optimizer not available — ryzen_smu module missing or does not support this platform"}
 	}
 	d.mu.Lock()
-	uv := d.state.Undervolt
 	profile := d.state.Profile
+	// Report the offset that "undervolt --set" with no profile would replace:
+	// the active custom profile's, or the default one's when a firmware profile
+	// is active. Values survive a switch to a stock profile so they can be
+	// recalled; Active is what says whether they are in hardware right now.
+	target, _ := d.resolveEditTargetLocked("")
+	uv := target.Profile.Undervolt
 	d.mu.Unlock()
 
 	uvState := api.UndervoltState{}
@@ -821,15 +855,32 @@ func (d *Daemon) handleUndervolt(req request) response {
 		return response{OK: false, Error: err.Error()}
 	}
 
-	if err := cli.SetCurveOptimizer(cpuOffset); err != nil {
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
 		return response{OK: false, Error: "undervolt: " + err.Error()}
 	}
+	d.mu.Unlock()
 
-	slog.Info("undervolt", "cpu", cpuOffset)
+	active := false
+	if target.Live {
+		if err := cli.SetCurveOptimizer(cpuOffset); err != nil {
+			return response{OK: false, Error: "undervolt: " + err.Error()}
+		}
+		active = true
+		slog.Info("undervolt", "cpu", cpuOffset, "profile", target.Name)
+	} else {
+		slog.Info("undervolt", "cpu", cpuOffset, "profile", target.Name, "applied", false)
+	}
+
+	p := target.Profile
+	p.Undervolt = &api.UndervoltState{CPUCO: cpuOffset, Active: active}
 	d.mu.Lock()
-	d.state.Undervolt = &api.UndervoltState{CPUCO: cpuOffset, Active: true}
-	d.state.Profile = "custom"
-	s := cloneState(d.state)
+	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
 		slog.Warn("failed to save state", "err", err)
@@ -837,19 +888,35 @@ func (d *Daemon) handleUndervolt(req request) response {
 	return response{OK: true}
 }
 
-func (d *Daemon) handleUndervoltReset() response {
+func (d *Daemon) handleUndervoltReset(req request) response {
 	if !cli.SMUProbeUndervolt() {
 		return response{OK: false, Error: "Curve Optimizer not available — ryzen_smu module missing or does not support this platform"}
 	}
 
-	if err := cli.ResetCurveOptimizer(); err != nil {
+	d.hwMu.Lock()
+	defer d.hwMu.Unlock()
+
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked(req.Profile)
+	if err != nil {
+		d.mu.Unlock()
 		return response{OK: false, Error: "undervolt-reset: " + err.Error()}
 	}
+	d.mu.Unlock()
 
-	slog.Info("undervolt-reset")
+	if target.Live {
+		if err := cli.ResetCurveOptimizer(); err != nil {
+			return response{OK: false, Error: "undervolt-reset: " + err.Error()}
+		}
+		slog.Info("undervolt-reset", "profile", target.Name)
+	} else {
+		slog.Info("undervolt-reset", "profile", target.Name, "applied", false)
+	}
+
+	p := target.Profile
+	p.Undervolt = nil
 	d.mu.Lock()
-	d.state.Undervolt = nil
-	s := cloneState(d.state)
+	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
 	if err := saveState(s); err != nil {
 		slog.Warn("failed to save state", "err", err)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -90,7 +90,7 @@ func (d *Daemon) handleConn(conn net.Conn) {
 		// presses, and the daemon only ever writes on it from here on.
 		_ = conn.SetReadDeadline(time.Time{})
 		writeResponse(conn, response{OK: true})
-		d.addSubscriber(conn)
+		d.addSubscriber(conn, req.Events)
 		return
 	}
 
@@ -413,9 +413,7 @@ func (d *Daemon) handleBatteryLimit(req request) response {
 	d.state.Battery = limit
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -460,9 +458,7 @@ func (d *Daemon) handlePanelOverdrive(req request) response {
 	d.state.PanelOverdrive = value
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -549,9 +545,7 @@ func (d *Daemon) handleFanCurve(req request) response {
 	d.mu.Lock()
 	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -590,9 +584,7 @@ func (d *Daemon) handleFanCurveReset(req request) response {
 	d.mu.Lock()
 	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -714,9 +706,7 @@ func (d *Daemon) handleTDP(req request) response {
 	d.mu.Lock()
 	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 
 	// With the limit safe again, put the fans back to what the profile actually
 	// describes: its own curve, or firmware auto when it has none. Releasing
@@ -759,9 +749,7 @@ func (d *Daemon) handleTDPReset(req request) response {
 		d.mu.Lock()
 		s := d.commitEditLocked(target, p)
 		d.mu.Unlock()
-		if err := saveState(s); err != nil {
-			slog.Warn("failed to save state", "err", err)
-		}
+		d.saveAndNotify(s)
 		slog.Info("tdp-reset", "profile", target.Name, "applied", false)
 		return response{OK: true}
 	}
@@ -805,9 +793,7 @@ func (d *Daemon) handleTDPReset(req request) response {
 	setUndervoltActive(d.state, false)
 	s := cloneState(d.state)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -882,9 +868,7 @@ func (d *Daemon) handleUndervolt(req request) response {
 	d.mu.Lock()
 	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 
@@ -918,9 +902,7 @@ func (d *Daemon) handleUndervoltReset(req request) response {
 	d.mu.Lock()
 	s := d.commitEditLocked(target, p)
 	d.mu.Unlock()
-	if err := saveState(s); err != nil {
-		slog.Warn("failed to save state", "err", err)
-	}
+	d.saveAndNotify(s)
 	return response{OK: true}
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -127,7 +127,7 @@ func TestHandleProfileCustomWithoutSavedSettings(t *testing.T) {
 	if resp.OK {
 		t.Fatal("profile --set custom with no saved settings was accepted, want a rejection")
 	}
-	if !strings.Contains(resp.Error, "no custom settings saved") {
+	if !strings.Contains(resp.Error, "no settings saved") {
 		t.Errorf("error = %q, want it to explain nothing is saved", resp.Error)
 	}
 }
@@ -214,5 +214,158 @@ func TestRequestUnmarshalsProtocolShape(t *testing.T) {
 	want := request{Cmd: "tdp", Set: "60", PL1: "55", PL2: "65", PL3: "70", Force: true}
 	if !reflect.DeepEqual(req, want) {
 		t.Errorf("request = %+v, want %+v", req, want)
+	}
+}
+
+// The profile handlers below stay strictly on validation and refusal paths.
+// internal/cli's sysfs path vars are unexported, so a daemon test that got past
+// validation into applyProfileLocked would rewrite the developer's real power
+// limits, fan mode, and Curve Optimizer offset — the same warning as
+// TestHandleTDPForceBoundaryRejections.
+
+func TestHandleProfileCreateRejectsBadNames(t *testing.T) {
+	d := &Daemon{}
+	for _, name := range []string{"", "quiet", "balanced", "performance", "custom", "Gaming", "my profile", "a/b"} {
+		resp := d.handleProfileCreate(request{Cmd: "profile-create", Set: name})
+		if resp.OK {
+			t.Errorf("profile-create %q was accepted, want a rejection", name)
+		}
+	}
+}
+
+// TestHandleProfileRejectsUnknownNames is the guard that keeps a typo out of
+// cli.SetProfile. Before named profiles the daemon forwarded any string to
+// platform_profile; a mistyped name would now reach ResetAllFanCurves and drop
+// the user's fan curve on the way to failing.
+func TestHandleProfileRejectsUnknownNames(t *testing.T) {
+	d := &Daemon{state: api.State{Profile: "balanced"}}
+	for _, name := range []string{"performanc", "low-power", "gaming"} {
+		resp := d.handleProfile(request{Cmd: "profile", Set: name})
+		if resp.OK {
+			t.Fatalf("profile --set %q was accepted, want a rejection before any hardware write", name)
+		}
+		if !strings.Contains(resp.Error, "unknown profile") {
+			t.Errorf("error for %q = %q, want it to say the profile is unknown", name, resp.Error)
+		}
+	}
+}
+
+func TestHandleProfileDeleteRefusals(t *testing.T) {
+	base := func() api.State {
+		return api.State{
+			Profile: "gaming",
+			CustomProfiles: map[string]api.CustomProfile{
+				"gaming":     {Name: "gaming"},
+				"battery-uv": {Name: "battery-uv"},
+				"spare":      {Name: "spare"},
+			},
+			Autoswitch: &api.AutoswitchState{Enabled: true, AC: "balanced", Battery: "battery-uv"},
+		}
+	}
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"unknown profile", "nope", "no saved profile"},
+		{"the active profile", "gaming", "active profile"},
+		{"referenced by autoswitch", "battery-uv", "autoswitch battery profile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Daemon{state: base()}
+			resp := d.handleProfileDelete(request{Cmd: "profile-delete", Set: tt.target})
+			if resp.OK {
+				t.Fatalf("deleting %q was accepted, want a rejection", tt.target)
+			}
+			if !strings.Contains(resp.Error, tt.want) {
+				t.Errorf("error = %q, want it to mention %q", resp.Error, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleAutoswitchRejectsUnknownTargets(t *testing.T) {
+	d := &Daemon{state: api.State{
+		CustomProfiles: map[string]api.CustomProfile{"battery-uv": {Name: "battery-uv"}},
+	}}
+	for _, req := range []request{
+		{Cmd: "autoswitch", Enabled: true, AC: "turbo", Battery: "battery-uv"},
+		{Cmd: "autoswitch", Enabled: true, AC: "balanced", Battery: "deleted"},
+	} {
+		resp := d.handleAutoswitch(req)
+		if resp.OK {
+			t.Errorf("autoswitch %+v was accepted, want a rejection", req)
+		}
+	}
+}
+
+// TestResolveEditTargetLocked covers where a setting command lands. The empty
+// name must behave exactly as z13ctl did before named profiles existed: create
+// and activate "custom" when a firmware profile is running.
+func TestResolveEditTargetLocked(t *testing.T) {
+	state := api.State{
+		Profile: "balanced",
+		CustomProfiles: map[string]api.CustomProfile{
+			"gaming": {Name: "gaming", TDP: &api.TDPState{PL1SPL: 70}},
+		},
+	}
+	tests := []struct {
+		name     string
+		active   string
+		arg      string
+		wantName string
+		wantLive bool
+		wantErr  bool
+	}{
+		{name: "empty on a firmware profile creates and activates custom", active: "balanced", arg: "", wantName: "custom", wantLive: true},
+		{name: "empty on a custom profile edits it in place", active: "gaming", arg: "", wantName: "gaming", wantLive: true},
+		{name: "naming the active profile is live", active: "gaming", arg: "gaming", wantName: "gaming", wantLive: true},
+		{name: "naming another profile is not live", active: "balanced", arg: "gaming", wantName: "gaming", wantLive: false},
+		{name: "custom is addressable before it exists", active: "balanced", arg: "custom", wantName: "custom", wantLive: false},
+		{name: "a firmware profile has nothing to edit", active: "balanced", arg: "balanced", wantErr: true},
+		{name: "an unsaved name is rejected", active: "balanced", arg: "nope", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := cloneState(state)
+			s.Profile = tt.active
+			d := &Daemon{state: s}
+			d.mu.Lock()
+			got, err := d.resolveEditTargetLocked(tt.arg)
+			d.mu.Unlock()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveEditTargetLocked(%q) error = %v, wantErr %v", tt.arg, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.Name != tt.wantName || got.Live != tt.wantLive {
+				t.Errorf("resolveEditTargetLocked(%q) = {Name:%q Live:%v}, want {Name:%q Live:%v}",
+					tt.arg, got.Name, got.Live, tt.wantName, tt.wantLive)
+			}
+		})
+	}
+}
+
+// TestEditTargetIsACopy guards commitEditLocked's premise: the target carries a
+// snapshot, so building the edited profile from it cannot mutate live state
+// before the commit — and cannot alias it afterwards.
+func TestEditTargetIsACopy(t *testing.T) {
+	d := &Daemon{state: api.State{
+		Profile: "gaming",
+		CustomProfiles: map[string]api.CustomProfile{
+			"gaming": {Name: "gaming", TDP: &api.TDPState{PL1SPL: 70}},
+		},
+	}}
+	d.mu.Lock()
+	target, err := d.resolveEditTargetLocked("")
+	d.mu.Unlock()
+	if err != nil {
+		t.Fatalf("resolveEditTargetLocked: %v", err)
+	}
+	target.Profile.TDP.PL1SPL = 5
+	if d.state.CustomProfiles["gaming"].TDP.PL1SPL != 70 {
+		t.Error("editing the target mutated live daemon state before any commit")
 	}
 }

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -92,17 +92,104 @@ func loadState() api.State {
 	for name, ls := range s.Devices {
 		s.Devices[name] = normalizeLightingState(ls, s.Lighting)
 	}
+	return migrateCustomProfiles(s)
+}
+
+// migrateCustomProfiles brings a loaded state up to the current schema.
+//
+// State files written before named profiles existed carry the custom fan curve,
+// TDP and undervolt in the top-level FanCurve/TDP/Undervolt fields; those become
+// the "custom" profile. Newer files carry CustomProfiles and the top-level
+// fields are only a projection of the active profile, so they are discarded and
+// rebuilt rather than trusted.
+//
+// It also drops any profile whose name is reserved. Validation rejects those at
+// the door, but state.json is a plain file a user can edit, and a custom profile
+// named "balanced" would otherwise shadow the firmware profile of that name.
+func migrateCustomProfiles(s api.State) api.State {
+	if s.CustomProfiles == nil && (s.FanCurve != nil || s.TDP != nil || s.Undervolt != nil) {
+		p := api.CustomProfile{
+			Name:      api.DefaultCustomProfile,
+			FanCurve:  s.FanCurve,
+			TDP:       s.TDP,
+			Undervolt: s.Undervolt,
+		}
+		if p.Undervolt != nil {
+			// Active describes hardware, which has not been written yet.
+			p.Undervolt.Active = false
+		}
+		s.CustomProfiles = map[string]api.CustomProfile{api.DefaultCustomProfile: p}
+		slog.Info("migrated saved custom settings into the \"custom\" profile")
+	}
+	for name := range s.CustomProfiles {
+		if api.IsStockProfileName(name) || name == "" {
+			slog.Warn("dropping custom profile with a reserved name", "profile", name)
+			delete(s.CustomProfiles, name)
+			continue
+		}
+		// The name field is what profile --list reports; a hand-edited file may
+		// disagree with the key, and the key is the addressable one.
+		p := s.CustomProfiles[name]
+		p.Name = name
+		s.CustomProfiles[name] = p
+	}
+	// An active profile that resolves to nothing — deleted by a hand edit, or
+	// dropped by a downgrade — must not be carried forward. Left in place it
+	// reads as neither stock nor custom, so nothing restores it and every later
+	// lookup falls through to an error. Clearing it makes effectiveProfile fall
+	// back to platform_profile, which is the honest answer.
+	if s.Profile != "" && !api.IsStockProfileName(s.Profile) && !s.IsCustomProfile(s.Profile) {
+		slog.Warn("saved profile no longer exists; falling back to the firmware profile", "profile", s.Profile)
+		s.Profile = ""
+	}
+
+	// The legacy fields are an output projection, never in-memory storage, so
+	// clear them here: leaving a copy behind invites a future edit to read the
+	// stale one instead of the profile map.
+	s.FanCurve, s.TDP, s.Undervolt = nil, nil, nil
+	return s
+}
+
+// withLegacyProjection returns s with the top-level FanCurve/TDP/Undervolt
+// fields filled in from the custom profile those fields used to mean.
+//
+// They are no longer storage — CustomProfiles is — but they remain part of the
+// get-state response and of the state file, so clients and daemons written
+// before named profiles existed keep working. Everything inside the daemon
+// reads the profile map; this projection exists purely for the wire, and is
+// applied at the two serialization boundaries (saveState and get-state).
+//
+// The source is the active custom profile, or "custom" when a firmware profile
+// is active — i.e. whatever a bare "undervolt --set" would edit and
+// "profile --set custom" would recall. Projecting nothing on a firmware profile
+// would be a regression on both sides: a GUI showing "saved undervolt, not
+// active" would lose the value it displays, and a downgrade taken while on a
+// firmware profile would write those settings away entirely. Active is false
+// throughout in that case, since a firmware profile clears the offset in
+// hardware, so nothing here can read as applied when it is not.
+func withLegacyProjection(s api.State) api.State {
+	p, ok := s.ActiveCustomProfile()
+	if !ok {
+		p = s.CustomProfiles[api.DefaultCustomProfile]
+	}
+	s.FanCurve = p.FanCurve
+	s.TDP = p.TDP
+	s.Undervolt = p.Undervolt
 	return s
 }
 
 // cloneState returns a deep copy of s that shares no mutable memory with it.
 //
-// api.State holds a map and four pointer fields, so the plain struct copy in
+// api.State holds two maps and five pointer fields, so the plain struct copy in
 // "s := d.state" still aliases live daemon state. Handlers release d.mu before
 // calling saveState, so marshaling an aliased snapshot races with any handler
-// that mutates the map or dereferences a pointer under the lock — a concurrent
+// that mutates a map or dereferences a pointer under the lock — a concurrent
 // map read/write, which the Go runtime turns into an unrecoverable crash rather
 // than a catchable panic. Always snapshot through this before unlocking.
+//
+// CustomProfiles needs a copy per entry, not just a new map header: each entry
+// carries three pointers and a slice, and a shallow copy would share every one
+// of them.
 func cloneState(s api.State) api.State {
 	c := s
 	if s.Devices != nil {
@@ -111,26 +198,62 @@ func cloneState(s api.State) api.State {
 			c.Devices[k] = v
 		}
 	}
-	if s.TDP != nil {
-		tdp := *s.TDP
-		c.TDP = &tdp
-	}
-	if s.Undervolt != nil {
-		uv := *s.Undervolt
-		c.Undervolt = &uv
-	}
-	if s.FanCurve != nil {
-		fc := *s.FanCurve
-		if s.FanCurve.Points != nil {
-			fc.Points = append([]api.FanCurvePoint(nil), s.FanCurve.Points...)
+	if s.CustomProfiles != nil {
+		c.CustomProfiles = make(map[string]api.CustomProfile, len(s.CustomProfiles))
+		for k, v := range s.CustomProfiles {
+			c.CustomProfiles[k] = cloneCustomProfile(v)
 		}
-		c.FanCurve = &fc
 	}
+	if s.Autoswitch != nil {
+		as := *s.Autoswitch
+		c.Autoswitch = &as
+	}
+	c.TDP = cloneTDP(s.TDP)
+	c.Undervolt = cloneUndervolt(s.Undervolt)
+	c.FanCurve = cloneFanCurve(s.FanCurve)
 	return c
 }
 
-// saveState atomically writes state to disk.
+// cloneCustomProfile deep-copies one profile, including the fan curve's points.
+func cloneCustomProfile(p api.CustomProfile) api.CustomProfile {
+	p.FanCurve = cloneFanCurve(p.FanCurve)
+	p.TDP = cloneTDP(p.TDP)
+	p.Undervolt = cloneUndervolt(p.Undervolt)
+	return p
+}
+
+func cloneFanCurve(fc *api.FanCurveState) *api.FanCurveState {
+	if fc == nil {
+		return nil
+	}
+	c := *fc
+	if fc.Points != nil {
+		c.Points = append([]api.FanCurvePoint(nil), fc.Points...)
+	}
+	return &c
+}
+
+func cloneTDP(t *api.TDPState) *api.TDPState {
+	if t == nil {
+		return nil
+	}
+	c := *t
+	return &c
+}
+
+func cloneUndervolt(uv *api.UndervoltState) *api.UndervoltState {
+	if uv == nil {
+		return nil
+	}
+	c := *uv
+	return &c
+}
+
+// saveState atomically writes state to disk. The legacy FanCurve/TDP/Undervolt
+// fields are projected from the active profile on the way out so that a daemon
+// from before named profiles existed still finds the active profile's settings.
 func saveState(s api.State) error {
+	s = withLegacyProjection(s)
 	path := statePath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err

--- a/internal/daemon/state_test.go
+++ b/internal/daemon/state_test.go
@@ -3,6 +3,7 @@ package daemon
 // state_test.go — Tests for state persistence: saveState, loadState, defaultState.
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -250,5 +251,205 @@ func TestLoadStateRepairsPartialDeviceEntries(t *testing.T) {
 	// Gaps are filled from the all-device state, not blindly from defaults.
 	if kb.Mode != "static" || kb.Color != "FF0000" {
 		t.Errorf("keyboard entry = %+v, want gaps filled from the all-device state", kb)
+	}
+}
+
+// TestLoadStateMigratesLegacyCustomSettings covers the upgrade path: a state
+// file written before named profiles existed carries the custom fan curve, TDP
+// and undervolt at the top level. They must become the "custom" profile, or
+// every user's saved settings disappear on the first start after upgrading.
+func TestLoadStateMigratesLegacyCustomSettings(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	path := filepath.Join(dir, "z13ctl", "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	legacy := `{
+	  "lighting": {"enabled": true, "mode": "static", "color": "FF0000", "color2": "000000", "speed": "normal", "brightness": 3},
+	  "profile": "custom",
+	  "fan_curve": {"mode": 1, "points": [{"temp": 40, "pwm": 50}]},
+	  "tdp": {"pl1_spl": 35, "pl2_sppt": 40},
+	  "undervolt": {"cpu_co": -25, "active": true}
+	}`
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := loadState()
+
+	p, ok := got.ActiveCustomProfile()
+	if !ok {
+		t.Fatalf("Profile %q is not custom after migration; the saved settings are unreachable", got.Profile)
+	}
+	if p.TDP == nil || p.TDP.PL1SPL != 35 {
+		t.Errorf("migrated TDP = %+v, want 35W", p.TDP)
+	}
+	if p.FanCurve == nil || len(p.FanCurve.Points) != 1 {
+		t.Errorf("migrated fan curve = %+v, want one point", p.FanCurve)
+	}
+	if p.Undervolt == nil || p.Undervolt.CPUCO != -25 {
+		t.Errorf("migrated undervolt = %+v, want CO -25", p.Undervolt)
+	}
+	// Active describes hardware, which has not been written on the way in.
+	if p.Undervolt != nil && p.Undervolt.Active {
+		t.Error("migrated undervolt claims to be applied before anything was written to the SMU")
+	}
+	// The top-level fields are an output projection only; leaving a copy in
+	// memory invites a later edit to read the stale one.
+	if got.FanCurve != nil || got.TDP != nil || got.Undervolt != nil {
+		t.Error("loadState left the legacy projection populated in memory")
+	}
+}
+
+// TestLoadStateDropsReservedProfileNames is the last of the four layers that
+// stop a custom profile shadowing a firmware one. The other three are
+// validation, api.State.IsCustomProfile, and applyProfileLocked's stock-first
+// switch; this one covers a hand-edited or downgrade-mangled state file, which
+// parses fine and so is never seen by any of them.
+func TestLoadStateDropsReservedProfileNames(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	path := filepath.Join(dir, "z13ctl", "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	hacked := `{
+	  "profile": "balanced",
+	  "custom_profiles": {
+	    "balanced": {"name": "balanced", "tdp": {"pl1_spl": 90}},
+	    "performance": {"name": "performance"},
+	    "gaming": {"name": "gaming", "tdp": {"pl1_spl": 70}}
+	  }
+	}`
+	if err := os.WriteFile(path, []byte(hacked), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := loadState()
+
+	for _, reserved := range api.StockProfiles {
+		if _, ok := got.CustomProfiles[reserved]; ok {
+			t.Errorf("custom profile %q survived load; it would shadow the firmware profile", reserved)
+		}
+	}
+	if got.IsCustomProfile("balanced") {
+		t.Error("IsCustomProfile(\"balanced\") = true after load, want false")
+	}
+	if _, ok := got.CustomProfiles["gaming"]; !ok {
+		t.Error("a legitimate profile was dropped along with the reserved ones")
+	}
+}
+
+func TestSaveAndLoadStateCustomProfilesRoundTrip(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	s := api.State{
+		Lighting: defaultState().Lighting,
+		Profile:  "battery-uv",
+		CustomProfiles: map[string]api.CustomProfile{
+			"battery-uv": {
+				Name:      "battery-uv",
+				TDP:       &api.TDPState{PL1SPL: 35, PL2SPPT: 40},
+				Undervolt: &api.UndervoltState{CPUCO: -25},
+			},
+		},
+		Autoswitch: &api.AutoswitchState{Enabled: true, AC: "balanced", Battery: "battery-uv"},
+	}
+	if err := saveState(s); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+	got := loadState()
+
+	if got.Profile != "battery-uv" {
+		t.Errorf("Profile = %q, want \"battery-uv\"", got.Profile)
+	}
+	p, ok := got.CustomProfiles["battery-uv"]
+	if !ok {
+		t.Fatal("the saved profile did not survive the round trip")
+	}
+	if p.TDP == nil || p.TDP.PL1SPL != 35 || p.Undervolt == nil || p.Undervolt.CPUCO != -25 {
+		t.Errorf("round-tripped profile = %+v", p)
+	}
+	if got.Autoswitch == nil || !got.Autoswitch.Enabled || got.Autoswitch.Battery != "battery-uv" {
+		t.Errorf("round-tripped autoswitch = %+v", got.Autoswitch)
+	}
+}
+
+// TestSaveStateWritesTheLegacyProjection covers downgrade tolerance: a daemon
+// from before named profiles reads only the top-level fields, so the active
+// profile's settings are written there too. Without this an upgrade followed by
+// a downgrade silently loses the user's custom settings.
+func TestSaveStateWritesTheLegacyProjection(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	if err := saveState(api.State{
+		Profile: "battery-uv",
+		CustomProfiles: map[string]api.CustomProfile{
+			"battery-uv": {Name: "battery-uv", TDP: &api.TDPState{PL1SPL: 35}},
+		},
+	}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "z13ctl", "state.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var raw struct {
+		TDP *api.TDPState `json:"tdp"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if raw.TDP == nil || raw.TDP.PL1SPL != 35 {
+		t.Errorf("top-level tdp in state.json = %+v, want the active profile's 35W", raw.TDP)
+	}
+}
+
+// TestLoadStateClearsAProfileThatNoLongerExists covers a state file naming a
+// custom profile that is gone — deleted by a hand edit, or dropped by a
+// downgrade. Carried forward it reads as neither firmware nor custom, so
+// nothing restores it, every lookup errors, and Run() would previously have
+// written the name straight to platform_profile.
+func TestLoadStateClearsAProfileThatNoLongerExists(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	path := filepath.Join(dir, "z13ctl", "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := `{"profile":"deleted-profile","custom_profiles":{"gaming":{"name":"gaming"}}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := loadState()
+	if got.Profile != "" {
+		t.Errorf("Profile = %q, want \"\" so effectiveProfile falls back to platform_profile", got.Profile)
+	}
+	if _, ok := got.CustomProfiles["gaming"]; !ok {
+		t.Error("a legitimate profile was dropped along with the dangling name")
+	}
+}
+
+// TestLoadStateKeepsResolvableProfiles is the premise guard for the test above:
+// it must not clear a name that does resolve.
+func TestLoadStateKeepsResolvableProfiles(t *testing.T) {
+	for _, name := range []string{"balanced", "performance", "custom", "gaming"} {
+		dir := t.TempDir()
+		t.Setenv("XDG_STATE_HOME", dir)
+		path := filepath.Join(dir, "z13ctl", "state.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		body := `{"profile":"` + name + `","custom_profiles":{"gaming":{"name":"gaming"}}}`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if got := loadState(); got.Profile != name {
+			t.Errorf("Profile = %q, want %q — a resolvable name was cleared", got.Profile, name)
+		}
 	}
 }


### PR DESCRIPTION
Closes #6.

Adds named custom profiles and automatic profile selection by power source: a
firmware profile on AC, a custom profile with an undervolt on battery, switched
on plug/unplug.

## Why both

Autoswitch needs to edit a profile you are **not** running — you build the
battery profile while plugged in. With a single anonymous `custom` slot that
would mean applying the battery profile to hardware first, so named profiles are
a precondition rather than a bonus.

## What's in it

- **Named custom profiles.** `profile --create/--save-as/--delete/--list`. A
  custom profile is a named set of fan curve, TDP and Curve Optimizer settings
  that z13ctl applies itself and never writes to `platform_profile`. `custom` is
  still the profile created implicitly by the first custom setting made on a
  firmware profile, so existing workflows are unchanged.
- **`--profile <name>`** on `fancurve`, `tdp` and `undervolt` stores a setting
  without applying it.
- **`autoswitch --ac X --battery Y`.** Edge-triggered on the charger's `online`
  attribute, never reads or writes `platform_profile` — so it cannot get into a
  write-fight with power-profiles-daemon. A profile chosen by hand sticks until
  the source actually changes. UPower signal where available, 2 s sysfs poll as
  backstop, with a settle window so the apply lands after PPD's own transition
  write.
- **Two client events** (`power-source`, `state-changed`), and `subscribe`'s
  `events` list is now honoured — it was previously ignored and every subscriber
  received everything.
- `status` shows the power source and the effective profile.

## Required before tagging a release

`go.mod` still requires `api v1.1.7`, so **this branch does not build without a
`go.work`** (which is gitignored). Per the documented multi-module workflow:

1. merge
2. `git tag api/v1.2.0 && git push origin api/v1.2.0`
3. bump `require github.com/dahui/z13ctl/api` to `v1.2.0`
4. `git tag v1.3.0`

## Compatibility

api v1.2.0 is additive — no signature changes, no removals, no import path
change.

- The `profile` request field is additive, so a **pre-1.3.0 daemon silently drops
  it and applies the setting to the running machine**. The CLI probes
  `profile-list` before any `--profile` edit and refuses if unsupported. Other
  clients must do the same.
- `state.Profile == "custom"` is no longer the test for custom settings; use
  `State.InCustomProfile()` / `ActiveCustomProfile()`. An existing z13gui build
  keeps working except that a *named* profile blanks its undervolt readout
  (display only).
- `profile --set` now rejects a name that is neither a firmware profile nor a
  saved one, where it previously forwarded any string to `platform_profile`.
- State files migrate automatically; existing custom settings become the `custom`
  profile. Downgrading drops named profiles.

## Behaviour changes worth review

- **Selecting a custom profile clears the subsystems it does not set** — no fan
  curve releases the fans, no undervolt resets CO, no TDP hands the limits back
  to the firmware profile underneath. Without this, switching between two custom
  profiles leaves the previous one's settings in force and A→B→A does not give
  the same machine as A.
- The firmware profile names are reserved at four layers, including on state-file
  load, so a hand-edited `custom_profiles` entry named `balanced` cannot shadow
  the firmware profile.
- A fan curve stored in a profile is validated against **that profile's own**
  sustained limit, so a profile cannot be saved in a state that would be unsafe
  when activated. `ApplyTDPSafely` still fails closed at activation.

## Testing

`make test`, `make lint` (0 issues, both modules), `go test -race`, and
`mkdocs build --strict` are clean.

Verified on hardware (2025 GZ302E) with power-profiles-daemon running:

- **AC → battery**: applied 2 s after the transition; 30 W, custom fan curve and
  CO −10 all took effect. Zero reconcile lines, i.e. the settle window kept the
  fan curve from being dropped by PPD's own `platform_profile` write.
- **battery → AC**: back to `balanced`, stock PPT restored, fans to auto, CO
  cleared. Exactly one journal line per physical transition, none in between.
- **Suspend/resume** on a custom profile: CO (which does not survive suspend),
  fan curve and TDP all restored on the first sample after wake; autoswitch
  correctly silent since the source did not change.
- **Daemon restart** landing on a firmware profile: fan curve and CO released
  rather than left running under a firmware profile's name.
- An old client built against api v1.1.7 was run against the new daemon to
  confirm the compatibility claims above.
