### PR TITLE
fix: wait for the EC to answer before restoring state on resume

### DIFF
--- a/internal/daemon/resume.go
+++ b/internal/daemon/resume.go
@@ -24,12 +24,19 @@ package daemon
 //   - PrepareForSleep(true) is advisory unless someone holds a delay inhibitor.
 //     Without one, logind is free to freeze userspace before these writes land,
 //     which looks exactly like the bug being fixed — hence takeSleepInhibitor.
+//   - PrepareForSleep(false) arrives early in the resume path, before the
+//     platform drivers have finished re-initialising. Restoring immediately can
+//     drive a PPT write into an embedded controller that is not answering yet,
+//     which wedges the ACPI global mutex and hard-locks the machine — hence
+//     waitForEC.
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"syscall"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 
@@ -117,14 +124,24 @@ func (d *Daemon) watchResume(ctx context.Context) {
 				releaseSleepInhibitor(&inhibitor)
 				continue
 			}
-			slog.Info("system resumed from sleep, restoring volatile state")
-			d.restoreVolatileState()
+			slog.Info("system resumed from sleep")
+			// Re-taken here rather than after the restore: waitForEC below can
+			// block for seconds, and logind must not be free to run an unheld
+			// suspend cycle in that window — that is the same gap takeSleepInhibitor
+			// exists to close.
+			//
 			// Release before re-taking. The sleep branch normally leaves this at -1,
 			// but nothing guarantees the two edges alternate — a (false) with no
 			// preceding (true) would otherwise overwrite a still-open fd, leaking it
 			// and leaving logind counting a delay lock nobody can release.
 			releaseSleepInhibitor(&inhibitor)
 			inhibitor = takeSleepInhibitor(conn)
+
+			if !waitForEC(ctx) {
+				continue
+			}
+			slog.Info("restoring volatile state")
+			d.restoreVolatileState()
 		}
 	}
 }
@@ -333,6 +350,68 @@ func releaseSleepInhibitor(fd *int) {
 		slog.Debug("failed to close the sleep delay inhibitor", "err", err)
 	}
 	*fd = -1
+}
+
+// EC settling after resume. logind emits PrepareForSleep(false) as soon as the
+// kernel returns from suspend, which is before the ASUS platform drivers have
+// finished re-initialising. Writing a PPT limit through asus_wmi in that window
+// blocks inside acpi_evaluate_object holding the ACPI global mutex; because that
+// mutex serialises every ACPI operation on the system, the EC event handler and
+// anything else touching thermals or battery pile up behind it and the NMI
+// watchdog starts reporting hard lockups across every core.
+const (
+	// ecSettleDelay is the unconditional pause before the EC is first probed.
+	ecSettleDelay = 3 * time.Second
+	// ecProbeInterval is how often the EC is probed after that pause.
+	ecProbeInterval = 1 * time.Second
+	// ecProbeTimeout bounds the total wait before restoring regardless.
+	ecProbeTimeout = 20 * time.Second
+)
+
+// ecResponds reports whether the EC is answering. Reading the battery capacity
+// is the cheapest available signal: while the EC is still coming up the sysfs
+// attribute is present but its device is not, so the read fails fast with
+// ENODEV rather than blocking on the ACPI mutex this whole function exists to
+// stay off.
+func ecResponds() bool {
+	_, err := os.ReadFile(cli.FindBatteryCapacityPath())
+	return err == nil
+}
+
+// waitForEC blocks until the EC answers, ctx is cancelled, or ecProbeTimeout
+// elapses. Returns false only on cancellation.
+func waitForEC(ctx context.Context) bool {
+	return waitForECWith(ctx, ecResponds, ecSettleDelay, ecProbeInterval, ecProbeTimeout)
+}
+
+// waitForECWith is waitForEC with its probe and timings injected, so the policy
+// can be tested without real sysfs or real delays.
+//
+// On timeout it returns true and lets the restore proceed rather than skipping
+// it: a machine with no battery at all (bench supply, pack removed) reports the
+// same way as a wedged EC, and must still get its profile back.
+func waitForECWith(ctx context.Context, responds func() bool, settle, interval, timeout time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(settle):
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if responds() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			slog.Warn("EC still unresponsive after resume; restoring anyway", "waited", timeout)
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(interval):
+		}
+	}
 }
 
 // restoreVolatileState reapplies all settings that are lost on sleep/resume:

--- a/internal/daemon/resume_test.go
+++ b/internal/daemon/resume_test.go
@@ -9,6 +9,7 @@ package daemon
 // their fan mode.
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -239,5 +240,53 @@ func TestSuspendCeilingExceedsInhibitDelay(t *testing.T) {
 		t.Errorf("stand-down budget is %v, which does not exceed a %v InhibitDelayMaxSec: "+
 			"the ceiling would fire inside a real pre-freeze window",
 			budget, longestPlausibleInhibitDelay)
+	}
+}
+
+func TestWaitForECWaitsForTheECToAnswer(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	responds := func() bool {
+		calls++
+		return calls >= 3
+	}
+	if !waitForECWith(t.Context(), responds, 0, time.Millisecond, time.Second) {
+		t.Fatal("waitForECWith reported cancellation for a probe that answered")
+	}
+	if calls != 3 {
+		t.Errorf("probed %d times, want 3: the loop must retry until the EC answers", calls)
+	}
+}
+
+func TestWaitForECRestoresAnywayOnTimeout(t *testing.T) {
+	t.Parallel()
+	// A machine with no battery reports exactly like a wedged EC. Skipping the
+	// restore there would strand it on whatever the firmware left behind.
+	never := func() bool { return false }
+	if !waitForECWith(t.Context(), never, 0, time.Millisecond, 5*time.Millisecond) {
+		t.Error("timeout returned false; a batteryless machine would never be restored")
+	}
+}
+
+func TestWaitForECAbandonsOnCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if waitForECWith(ctx, func() bool { return false }, time.Hour, time.Hour, time.Hour) {
+		t.Error("a cancelled context must abandon the wait, not restore")
+	}
+}
+
+func TestECWaitFitsInsideSuspendCeiling(t *testing.T) {
+	t.Parallel()
+	// restoreVolatileState clears the suspending flag, so the EC wait holds it
+	// set for its whole duration. If that could outlast the reconcile watcher's
+	// stand-down budget the watcher would log a stale-flag warning and start
+	// defending the fans mid-resume — against the very EC being waited on.
+	worst := ecSettleDelay + ecProbeTimeout
+	budget := time.Duration(reconcileSuspendMaxTicks) * reconcilePollInterval
+	if worst >= budget {
+		t.Errorf("worst-case EC wait is %v but the reconcile stand-down budget is %v: "+
+			"the watcher would wake up inside a resume", worst, budget)
 	}
 }


### PR DESCRIPTION
## The problem

`watchResume` calls `restoreVolatileState()` synchronously the moment `PrepareForSleep(false)` arrives. logind emits that as soon as the kernel returns from suspend — before the ASUS platform drivers have finished re-initialising — so the PPT writes can land in an embedded controller that is not answering yet.

`asus_wmi` does those writes through `acpi_evaluate_object`, which takes the **ACPI global mutex**. If the EC never replies, that mutex is held indefinitely, and since it serialises every ACPI operation on the system, the EC event handler and everything else touching thermals or battery queue up behind it. The machine hard-locks across every core and only a power-button hold recovers it.

The sleep side of this file is already careful about exactly this class of problem — the delay inhibitor exists so the pre-suspend writes land before userspace freezes. The resume edge has no equivalent guard.

## Evidence

From a GZ302EA on `7.0.0-29-generic`, after a resume that left the EC degraded (`ucsi_acpi ... failed to re-enable notifications (-110)`, `BAT0/energy_now: No such device`):

```
watchdog: CPU7: Watchdog detected hard LOCKUP on cpu 7
Workqueue: kec acpi_ec_event_handler
RIP: advance_transaction+0x30/0x540
  acpi_ec_transaction_unlocked -> acpi_ec_transaction -> acpi_ec_submit_query
```

and the deadlock itself, naming both sides:

```
INFO: task z13ctl blocked for more than 122 seconds.
  ppt_fppt_store [asus_wmi] -> wmi_evaluate_method -> acpi_evaluate_object
  -> acpi_ex_system_wait_mutex -> __down_timeout

INFO: task z13ctl blocked on a semaphore likely last held by task tokio-rt-worker
task:tokio-rt-worker  RIP: acpi_os_read_port+0x2e   (RDI: 0x258)
```

`tokio-rt-worker` is `asusd`, holding the ACPI lock on an EC port read that never returned; z13ctl's PPT write queued behind it. About 14 minutes later ~25 CPUs were soft-locked and the power button was unresponsive. Resume was at 07:33:16, first hard lockup 07:34:29.

Worth noting the trigger needs no second daemon — anything that makes the EC slow to come back after resume reaches the same place. `asusd` just made it easy to catch in the act.

## The fix

Pause 3s after the resume edge, then poll the battery capacity attribute until it reads back cleanly before touching any ACPI/WMI attribute. That read fails fast with `ENODEV` while the EC is still coming up, rather than blocking on the very mutex being avoided — deliberately not a probe that itself takes the ACPI path.

Bounded at 20s, after which it restores anyway: a machine with no battery reports identically to a wedged EC and must still get its profile back.

The inhibitor is now re-taken *before* the wait rather than after the restore, so logind cannot begin an unheld suspend cycle during it. Release-before-re-take is preserved, along with the fd-leak reasoning in that comment.

## On the suspending flag

`restoreVolatileState` clears `suspending`, so deferring it holds the flag set for the duration of the wait. Worst case is 23s against the reconcile watcher's `60 * 2s = 120s` stand-down budget, so it cannot go stale mid-resume. `TestECWaitFitsInsideSuspendCeiling` pins that relationship in the same spirit as the existing `TestSuspendCeilingExceedsInhibitDelay` — if either constant moves, the test says so.

## Testing

Policy is split into `waitForECWith`, following the pure-core approach the rest of `resume_test.go` uses, so no test touches real sysfs or real delays. Four new cases: retries until the EC answers, restores anyway on timeout, abandons on context cancellation, and the ceiling invariant. Full suite, `gofmt` and `go vet` all clean.

The 3s / 20s figures are chosen to comfortably cover the observed window, not measured against a range of hardware — happy to adjust if you have a better sense of the spread.