### PR TITLE
fix: reopen the HID device on resume before restoring lighting

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -479,21 +479,34 @@ func (d *Daemon) reopenAndRestore() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	dev, err := hid.FindDevice("")
-	if err != nil {
+	if err := d.reopenDeviceLocked(); err != nil {
 		slog.Warn("hotplug: failed to reopen HID device", "err", err)
 		return false
 	}
-	if d.dev != nil {
-		d.dev.Close()
-	}
-	d.dev = dev
 	if err := d.applyLightingState(); err != nil {
 		slog.Warn("hotplug: failed to restore lighting", "err", err)
 		return false
 	}
 	slog.Info("keyboard reattached; lighting restored")
 	return true
+}
+
+// reopenDeviceLocked replaces d.dev with a freshly opened handle, closing the
+// previous one. Split out of reopenAndRestore because the resume path needs the
+// reopen without the hotplug logging and while already holding d.mu.
+//
+// The caller must hold d.mu: d.dev is read by applyLightingState and by every
+// socket handler that touches lighting.
+func (d *Daemon) reopenDeviceLocked() error {
+	dev, err := hid.FindDevice("")
+	if err != nil {
+		return err
+	}
+	if d.dev != nil {
+		d.dev.Close()
+	}
+	d.dev = dev
+	return nil
 }
 
 // applyLightingState restores lighting from the saved state. d.dev must be non-nil.

--- a/internal/daemon/resume.go
+++ b/internal/daemon/resume.go
@@ -358,7 +358,19 @@ func (d *Daemon) restoreVolatileState() {
 	d.mu.Lock()
 	state := cloneState(d.state)
 	if d.dev != nil {
-		if err := d.applyLightingState(); err != nil {
+		// USB re-enumerates across suspend, so the handle opened at startup (or
+		// at the last reattach) usually points at a hidraw node that no longer
+		// exists — the write then fails with ENODEV and the lighting is never
+		// restored. The hotplug watcher does not cover this: it fires on an
+		// absent -> present transition, and the keyboard comes back faster than
+		// its 2 s poll can observe it missing, so the stale handle is never
+		// replaced.
+		//
+		// A failed reopen leaves d.dev as it was, which is exactly the previous
+		// behaviour, so this can only improve on it.
+		if err := d.reopenDeviceLocked(); err != nil {
+			slog.Warn("resume: failed to reopen HID device", "err", err)
+		} else if err := d.applyLightingState(); err != nil {
 			slog.Warn("resume: failed to restore lighting", "err", err)
 		} else {
 			slog.Info("resume: lighting restored")


### PR DESCRIPTION
## The problem

`restoreVolatileState` applies the saved lighting through the cached `d.dev`. USB re-enumerates across suspend, so that handle points at a hidraw node that no longer exists and every write fails:

```
WARN resume: failed to restore lighting
     err="init packet 1: write to /dev/hidraw2: write /dev/hidraw2: no such device"
```

`reopenAndRestore` already does the right thing — it calls `hid.FindDevice("")` for a fresh handle — but the resume path never reaches it. `watchHotplug` fires only on an **absent → present** transition, and on resume the keyboard returns faster than the 2s poll can observe it missing, so `present` stays latched and the stale handle is never replaced. The watcher is built for the detachable keyboard being physically removed, which a resume does not resemble.

## Evidence

Measured on a GZ302EA across a single 9-day uptime:

| | |
|---|---|
| resumes | 108 |
| `resume: failed to restore lighting` | 108 |
| `resume: lighting restored` | 0 |

Not intermittent — it has never once succeeded. A fresh scan straight after such a resume shows the hardware present and healthy at its new nodes, which is exactly what the daemon was failing to reopen:

```
/dev/hidraw3     keyboard    [Aura/0x5d confirmed]
/dev/hidraw10    lightbar    [Aura/0x5d confirmed]
```

There is no `hidraw2` or `hidraw7` on the system any more.

## The fix

Reopen before applying, through the same call `reopenAndRestore` makes. The reopen is split into `reopenDeviceLocked` so the resume path can use it while already holding `d.mu`, and so `reopenAndRestore` keeps its hotplug-specific logging.

A failed reopen leaves `d.dev` exactly as it was, which is the current behaviour, so this can only improve on it.

## Verified

Same machine, first suspend/resume on the patched build:

```
09:55:05.983  INFO system resumed from sleep
09:55:08.991  INFO restoring volatile state
09:55:09.136  INFO lighting restored zone=keyboard mode=static brightness=3
09:55:09.178  INFO lighting restored zone=lightbar mode=static brightness=3
09:55:09.178  INFO resume: lighting restored
```

Both zones, where the previous 108 attempts produced `ENODEV`.

## Notes

No new unit test. The change is a reordering of two I/O calls with no new decision logic, and the reopen path it reuses is itself untested for the same reason — `hid.FindDevice` needs real hardware, and `resume_test.go` deliberately keeps to pure functions so a test run cannot rewrite the developer's lighting. Happy to add coverage if you would take an injected-seam approach here.

Independent of #20 and applies cleanly without it. If both land, note that #20's post-resume settle also gives USB re-enumeration time to finish before this reopen runs, which makes the reopen more reliable than it is alone.